### PR TITLE
Features/dependency injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = [{ name = "Guillaume Gauvrit", email = "guillaume@gauvr.it" }]
 description = "A message bus library"
 name = "messagebus"
 version = "0.7.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 
 dependencies = [
@@ -48,7 +48,7 @@ includes = ["src", "CHANGELOG.rst"]
 excludes = ["tests"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]
@@ -59,7 +59,6 @@ select = [
     "UP",  # alter when better syntax is available
     "RUF", #  the ruff devleoper's own rules
 ]
-ignore = ["UP007"] # py39 !
 
 [tool.pyright]
 ignore = ["examples"]

--- a/src/messagebus/service/_async/registry.py
+++ b/src/messagebus/service/_async/registry.py
@@ -109,7 +109,7 @@ class AsyncMessageBus(Generic[TRepositories]):
         ret = None
         while queue:
             message = queue.pop(0)
-            if not isinstance(message, (GenericCommand, GenericEvent)):
+            if not isinstance(message, GenericCommand | GenericEvent):
                 raise RuntimeError(f"{message} was not an Event or Command")
             msg_type = type(message)
             if msg_type in self.commands_registry:

--- a/src/messagebus/service/_async/repository.py
+++ b/src/messagebus/service/_async/repository.py
@@ -9,7 +9,7 @@ storage.
 
 import abc
 from collections.abc import MutableSequence
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from messagebus.domain.model import GenericModel, Message
 from messagebus.service._async.eventstream import AsyncEventstreamPublisher
@@ -27,7 +27,7 @@ class AsyncAbstractRepository(abc.ABC, Generic[TModel_contra]):
 
 
 class AsyncEventstoreAbstractRepository(abc.ABC):
-    def __init__(self, publisher: Optional[AsyncEventstreamPublisher] = None) -> None:
+    def __init__(self, publisher: AsyncEventstreamPublisher | None = None) -> None:
         self.publisher = publisher
         self.stream_buffer: MutableSequence[Message[Any]] = []
 

--- a/src/messagebus/service/_async/unit_of_work.py
+++ b/src/messagebus/service/_async/unit_of_work.py
@@ -6,7 +6,7 @@ import abc
 import enum
 from collections.abc import Iterator
 from types import TracebackType
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from messagebus.domain.model import Message
 from messagebus.service._async.repository import (
@@ -64,9 +64,9 @@ class AsyncUnitOfWorkTransaction(Generic[TRepositories]):
 
     async def __aexit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         """Rollback in case of exception."""
         if exc:
@@ -116,9 +116,9 @@ class AsyncAbstractUnitOfWork(abc.ABC, Generic[TRepositories]):
 
     async def __aexit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         # AsyncUnitOfWorkTransaction is making the thing
         await self.__transaction.__aexit__(exc_type, exc, tb)

--- a/src/messagebus/service/_sync/registry.py
+++ b/src/messagebus/service/_sync/registry.py
@@ -109,7 +109,7 @@ class SyncMessageBus(Generic[TRepositories]):
         ret = None
         while queue:
             message = queue.pop(0)
-            if not isinstance(message, (GenericCommand, GenericEvent)):
+            if not isinstance(message, GenericCommand | GenericEvent):
                 raise RuntimeError(f"{message} was not an Event or Command")
             msg_type = type(message)
             if msg_type in self.commands_registry:

--- a/src/messagebus/service/_sync/registry.py
+++ b/src/messagebus/service/_sync/registry.py
@@ -7,6 +7,7 @@ import importlib
 import inspect
 import logging
 from collections import defaultdict
+from functools import partial
 from typing import Any, Generic, cast
 
 import venusian  # type: ignore
@@ -52,7 +53,7 @@ def sync_listen(
 class SyncMessageBus(Generic[TRepositories]):
     """Store all the handlers for commands an events."""
 
-    def __init__(self) -> None:
+    def __init__(self, **dependencies: Any) -> None:
         self.commands_registry: dict[
             type[GenericCommand[Any]],
             SyncMessageHandler[GenericCommand[Any], Any, ...],
@@ -61,10 +62,23 @@ class SyncMessageBus(Generic[TRepositories]):
             type[GenericEvent[Any]],
             list[SyncMessageHandler[GenericEvent[Any], Any, ...]],
         ] = defaultdict(list)
+        self.depencencies = dependencies or {}
 
     def add_listener(
         self, msg_type: type[Message[Any]], callback: SyncMessageHandler[Any, Any, P]
     ) -> None:
+        signature = inspect.signature(callback)
+        kwargs = {}
+        for idx, key in enumerate(signature.parameters):
+            if idx >= 2:
+                if key not in self.depencencies:
+                    raise ConfigurationError(
+                        f"Missing dependency in message bus: {key} for command "
+                        f"type {msg_type.__name__}, listener: {callback.__name__}"
+                    )
+                kwargs[key] = self.depencencies[key]
+        if kwargs:
+            callback = partial(callback, **kwargs)  # type: ignore
         if issubclass(msg_type, GenericCommand):
             if msg_type in self.commands_registry:
                 raise ConfigurationError(

--- a/src/messagebus/service/_sync/repository.py
+++ b/src/messagebus/service/_sync/repository.py
@@ -9,7 +9,7 @@ storage.
 
 import abc
 from collections.abc import MutableSequence
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from messagebus.domain.model import GenericModel, Message
 from messagebus.service._sync.eventstream import SyncEventstreamPublisher
@@ -27,7 +27,7 @@ class SyncAbstractRepository(abc.ABC, Generic[TModel_contra]):
 
 
 class SyncEventstoreAbstractRepository(abc.ABC):
-    def __init__(self, publisher: Optional[SyncEventstreamPublisher] = None) -> None:
+    def __init__(self, publisher: SyncEventstreamPublisher | None = None) -> None:
         self.publisher = publisher
         self.stream_buffer: MutableSequence[Message[Any]] = []
 

--- a/src/messagebus/service/_sync/unit_of_work.py
+++ b/src/messagebus/service/_sync/unit_of_work.py
@@ -6,7 +6,7 @@ import abc
 import enum
 from collections.abc import Iterator
 from types import TracebackType
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from messagebus.domain.model import Message
 from messagebus.service._sync.repository import (
@@ -64,9 +64,9 @@ class SyncUnitOfWorkTransaction(Generic[TRepositories]):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         """Rollback in case of exception."""
         if exc:
@@ -116,9 +116,9 @@ class SyncAbstractUnitOfWork(abc.ABC, Generic[TRepositories]):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         # AsyncUnitOfWorkTransaction is making the thing
         self.__transaction.__exit__(exc_type, exc, tb)

--- a/src/messagebus/typing.py
+++ b/src/messagebus/typing.py
@@ -5,7 +5,7 @@ Propagate commands and events to every registered handles.
 
 import logging
 from collections.abc import Callable, Coroutine
-from typing import Any, TypeVar
+from typing import Any, Concatenate, ParamSpec, TypeVar
 
 from messagebus.domain.model import Message
 
@@ -14,9 +14,13 @@ from .service._sync.unit_of_work import SyncAbstractUnitOfWork
 
 log = logging.getLogger(__name__)
 
+P = ParamSpec("P")
+
 TAsyncUow = TypeVar("TAsyncUow", bound=AsyncAbstractUnitOfWork[Any])
 TSyncUow = TypeVar("TSyncUow", bound=SyncAbstractUnitOfWork[Any])
 TMessage = TypeVar("TMessage", bound=Message[Any])
 
-AsyncMessageHandler = Callable[[TMessage, TAsyncUow], Coroutine[Any, Any, Any]]
-SyncMessageHandler = Callable[[TMessage, TSyncUow], Any]
+AsyncMessageHandler = Callable[
+    Concatenate[TMessage, TAsyncUow, P], Coroutine[Any, Any, Any]
+]
+SyncMessageHandler = Callable[Concatenate[TMessage, TSyncUow, P], Any]

--- a/tests/_async/conftest.py
+++ b/tests/_async/conftest.py
@@ -129,6 +129,11 @@ class DummyCommand(GenericCommand[MyMetadata]):
     )
 
 
+class AnotherDummyCommand(GenericCommand[MyMetadata]):
+    id: str = Field(...)
+    metadata: MyMetadata = MyMetadata(name="dummy2", schema_version=1, custom_field="f")
+
+
 class DummyEvent(GenericEvent[MyMetadata]):
     id: str = Field(...)
     increment: int = Field(...)

--- a/tests/_async/conftest.py
+++ b/tests/_async/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator, Mapping, MutableMapping, MutableSeque
 from types import EllipsisType
 from typing import (
     Any,
+    ClassVar,
 )
 
 import pytest
@@ -43,6 +44,13 @@ class DummyError(enum.Enum):
 class DummyModel(GenericModel[MyMetadata]):
     id: str = Field()
     counter: int = Field(0)
+
+
+class Notifier:
+    inbox: ClassVar[list[str]] = []
+
+    def send_message(self, message: str):
+        self.inbox.append(message)
 
 
 DummyRepositoryOperationResult = Result[EllipsisType, DummyError]
@@ -199,8 +207,13 @@ async def uow_with_eventstore(
 
 
 @pytest.fixture
-def bus() -> AsyncMessageBus[Repositories]:
-    return AsyncMessageBus()
+def notifier():
+    return Notifier()
+
+
+@pytest.fixture
+def bus(notifier: Notifier) -> AsyncMessageBus[Repositories]:
+    return AsyncMessageBus(notifier=notifier)
 
 
 @pytest.fixture

--- a/tests/_async/conftest.py
+++ b/tests/_async/conftest.py
@@ -1,9 +1,8 @@
 import enum
 from collections.abc import AsyncIterator, Mapping, MutableMapping, MutableSequence
+from types import EllipsisType
 from typing import (
     Any,
-    Optional,
-    Union,
 )
 
 import pytest
@@ -30,12 +29,6 @@ from messagebus.service._async.unit_of_work import (
     AsyncAbstractUnitOfWork,
     AsyncUnitOfWorkTransaction,
 )
-
-try:
-    # does not exists in python 3.7
-    from types import EllipsisType  # type:ignore
-except ImportError:
-    EllipsisType = Any  # type:ignore
 
 
 class MyMetadata(Metadata):
@@ -80,7 +73,7 @@ class AsyncDummyRepository(AsyncAbstractRepository[DummyModel]):
 class AsyncFooRepository(AsyncDummyRepository): ...
 
 
-Repositories = Union[AsyncDummyRepository, AsyncFooRepository]
+Repositories = AsyncDummyRepository | AsyncFooRepository
 
 
 class AsyncDummyUnitOfWork(AsyncAbstractUnitOfWork[Repositories]):
@@ -110,7 +103,7 @@ class AsyncEventstreamTransport(AsyncAbstractEventstreamTransport):
 class AsyncDummyEventStore(AsyncEventstoreAbstractRepository):
     messages: MutableSequence[Message[MyMetadata]]
 
-    def __init__(self, publisher: Optional[AsyncEventstreamPublisher]):
+    def __init__(self, publisher: AsyncEventstreamPublisher | None):
         super().__init__(publisher=publisher)
         self.messages = []
 
@@ -119,7 +112,7 @@ class AsyncDummyEventStore(AsyncEventstoreAbstractRepository):
 
 
 class AsyncDummyUnitOfWorkWithEvents(AsyncAbstractUnitOfWork[Repositories]):
-    def __init__(self, publisher: Optional[AsyncEventstreamPublisher]) -> None:
+    def __init__(self, publisher: AsyncEventstreamPublisher | None) -> None:
         self.foos = AsyncFooRepository()
         self.bars = AsyncDummyRepository()
         self.eventstore = AsyncDummyEventStore(publisher=publisher)

--- a/tests/_async/handlers/dummy.py
+++ b/tests/_async/handlers/dummy.py
@@ -1,15 +1,13 @@
-from typing import Any, ClassVar
+from typing import Any
 
 from messagebus.service._async.registry import async_listen
 from messagebus.service._async.unit_of_work import AsyncAbstractUnitOfWork
-from tests._async.conftest import AnotherDummyCommand, DummyCommand, DummyEvent
-
-
-class Notifier:
-    inbox: ClassVar[list[str]] = []
-
-    def send_message(self, message: str):
-        self.inbox.append(message)
+from tests._async.conftest import (
+    AnotherDummyCommand,
+    DummyCommand,
+    DummyEvent,
+    Notifier,
+)
 
 
 @async_listen

--- a/tests/_async/handlers/dummy.py
+++ b/tests/_async/handlers/dummy.py
@@ -1,8 +1,15 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from messagebus.service._async.registry import async_listen
 from messagebus.service._async.unit_of_work import AsyncAbstractUnitOfWork
-from tests._async.conftest import DummyCommand, DummyEvent
+from tests._async.conftest import AnotherDummyCommand, DummyCommand, DummyEvent
+
+
+class Notifier:
+    inbox: ClassVar[list[str]] = []
+
+    def send_message(self, message: str):
+        self.inbox.append(message)
 
 
 @async_listen
@@ -15,3 +22,11 @@ async def handler_evt1(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any]): 
 
 @async_listen
 async def handler_evt2(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any]): ...
+
+
+@async_listen
+async def handler_with_dependency_injection(
+    command: AnotherDummyCommand,
+    uow: AsyncAbstractUnitOfWork[Any],
+    notifier: Notifier,
+): ...

--- a/tests/_async/test_dependency.py
+++ b/tests/_async/test_dependency.py
@@ -1,0 +1,40 @@
+from messagebus.service._async.registry import AsyncMessageBus
+from messagebus.service._async.unit_of_work import AsyncUnitOfWorkTransaction
+from tests._async.conftest import (
+    AsyncDummyUnitOfWorkWithEvents,
+    AsyncEventstreamTransport,
+    DummyCommand,
+    DummyEvent,
+    DummyModel,
+    Notifier,
+    Repositories,
+)
+
+
+async def listen_command(
+    cmd: DummyCommand,
+    uow: AsyncUnitOfWorkTransaction[Repositories],
+    notifier: Notifier,
+) -> DummyModel:
+    """This command raise an event played by the message bus."""
+    foo = DummyModel(id=cmd.id, counter=0)
+    foo.messages.append(DummyEvent(id=foo.id, increment=10))
+    await uow.foos.add(foo)
+    notifier.send_message(f"Foo {cmd.id} ordered")
+    return foo
+
+
+async def test_store_events_and_publish(
+    bus: AsyncMessageBus[Repositories],
+    eventstream_transport: AsyncEventstreamTransport,
+    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    dummy_command: DummyCommand,
+    notifier: Notifier,
+):
+    bus.add_listener(DummyCommand, listen_command)
+    async with uow_with_eventstore as tuow:
+        await bus.handle(dummy_command, tuow)
+        await tuow.commit()
+    assert notifier.inbox == [
+        "Foo dummy_cmd ordered",
+    ]

--- a/tests/_async/test_registry.py
+++ b/tests/_async/test_registry.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 import pytest
@@ -10,6 +11,7 @@ from tests._async.conftest import (
     DummyModel,
     Repositories,
 )
+from tests._async.handlers import dummy
 
 conftest_mod = __name__.replace("test_registry", "conftest")
 
@@ -149,7 +151,6 @@ def test_scan(bus: AsyncMessageBus[Any]):
     assert bus.commands_registry == {}
     assert bus.events_registry == {}
     bus.scan("tests._async.handlers")
-    from tests._async.handlers import dummy
 
     assert DummyCommand in bus.commands_registry
     assert bus.commands_registry[DummyCommand] == dummy.handler
@@ -164,4 +165,40 @@ def test_scan_relative(bus: AsyncMessageBus[Any]):
     assert (
         str(ctx.value)
         == "scan error: relative package unsupported for ._async.handlers"
+    )
+
+
+async def listen_command_with_dependency(
+    cmd: DummyCommand,
+    uow: AsyncUnitOfWorkTransaction[Repositories],
+    dummy_dict: dict[str, str],
+) -> DummyModel:
+    """This command raise an event played by the message bus."""
+    foo = DummyModel(id=cmd.id, counter=0)
+    dummy_dict["foo"] = "bar"
+    return foo
+
+
+async def test_messagebus_dependency(
+    uow: AsyncUnitOfWorkTransaction[Repositories],
+):
+    d: dict[str, str] = {}
+    bus = AsyncMessageBus[Repositories](dummy_dict=d)
+    bus.add_listener(DummyCommand, listen_command_with_dependency)
+    assert isinstance(bus.commands_registry[DummyCommand], functools.partial)
+    assert (
+        bus.commands_registry[DummyCommand].keywords  # type: ignore
+        == {"dummy_dict": d}
+    )
+
+
+async def test_messagebus_dependency_error_missing_deps(
+    uow: AsyncUnitOfWorkTransaction[Repositories],
+):
+    bus = AsyncMessageBus[Repositories]()
+    with pytest.raises(ConfigurationError) as ctx:
+        bus.add_listener(DummyCommand, listen_command_with_dependency)
+    assert (
+        str(ctx.value) == "Missing dependency in message bus: dummy_dict for "
+        "command type DummyCommand, listener: listen_command_with_dependency"
     )

--- a/tests/_async/test_registry.py
+++ b/tests/_async/test_registry.py
@@ -47,9 +47,9 @@ async def test_messagebus(
 
     foo = await listen_command(DummyCommand(id="foo"), tuow)
     assert list(tuow.uow.collect_new_events()) == [DummyEvent(id="foo", increment=10)]
-    assert (
-        DummyModel.counter == 0
-    ), "Events raised cannot be played before the attach_listener has been called"
+    assert DummyModel.counter == 0, (
+        "Events raised cannot be played before the attach_listener has been called"
+    )
 
     await listen_event(DummyEvent(id="foo", increment=1), tuow)
     assert foo.counter == 1
@@ -69,9 +69,9 @@ async def test_messagebus(
     bus.remove_listener(DummyEvent, listen_event)
 
     foo = await bus.handle(DummyCommand(id="foo4"), tuow)
-    assert (
-        foo.counter == 0
-    ), "The command should raise an event that is not handled anymore "
+    assert foo.counter == 0, (
+        "The command should raise an event that is not handled anymore "
+    )
 
 
 async def test_messagebus_handle_only_message(

--- a/tests/_sync/conftest.py
+++ b/tests/_sync/conftest.py
@@ -129,6 +129,11 @@ class DummyCommand(GenericCommand[MyMetadata]):
     )
 
 
+class AnotherDummyCommand(GenericCommand[MyMetadata]):
+    id: str = Field(...)
+    metadata: MyMetadata = MyMetadata(name="dummy2", schema_version=1, custom_field="f")
+
+
 class DummyEvent(GenericEvent[MyMetadata]):
     id: str = Field(...)
     increment: int = Field(...)

--- a/tests/_sync/conftest.py
+++ b/tests/_sync/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator, Mapping, MutableMapping, MutableSequence
 from types import EllipsisType
 from typing import (
     Any,
+    ClassVar,
 )
 
 import pytest
@@ -43,6 +44,13 @@ class DummyError(enum.Enum):
 class DummyModel(GenericModel[MyMetadata]):
     id: str = Field()
     counter: int = Field(0)
+
+
+class Notifier:
+    inbox: ClassVar[list[str]] = []
+
+    def send_message(self, message: str):
+        self.inbox.append(message)
 
 
 DummyRepositoryOperationResult = Result[EllipsisType, DummyError]
@@ -199,8 +207,13 @@ def uow_with_eventstore(
 
 
 @pytest.fixture
-def bus() -> SyncMessageBus[Repositories]:
-    return SyncMessageBus()
+def notifier():
+    return Notifier()
+
+
+@pytest.fixture
+def bus(notifier: Notifier) -> SyncMessageBus[Repositories]:
+    return SyncMessageBus(notifier=notifier)
 
 
 @pytest.fixture

--- a/tests/_sync/conftest.py
+++ b/tests/_sync/conftest.py
@@ -1,9 +1,8 @@
 import enum
 from collections.abc import Iterator, Mapping, MutableMapping, MutableSequence
+from types import EllipsisType
 from typing import (
     Any,
-    Optional,
-    Union,
 )
 
 import pytest
@@ -30,12 +29,6 @@ from messagebus.service._sync.unit_of_work import (
     SyncAbstractUnitOfWork,
     SyncUnitOfWorkTransaction,
 )
-
-try:
-    # does not exists in python 3.7
-    from types import EllipsisType  # type:ignore
-except ImportError:
-    EllipsisType = Any  # type:ignore
 
 
 class MyMetadata(Metadata):
@@ -80,7 +73,7 @@ class SyncDummyRepository(SyncAbstractRepository[DummyModel]):
 class SyncFooRepository(SyncDummyRepository): ...
 
 
-Repositories = Union[SyncDummyRepository, SyncFooRepository]
+Repositories = SyncDummyRepository | SyncFooRepository
 
 
 class SyncDummyUnitOfWork(SyncAbstractUnitOfWork[Repositories]):
@@ -110,7 +103,7 @@ class SyncEventstreamTransport(SyncAbstractEventstreamTransport):
 class SyncDummyEventStore(SyncEventstoreAbstractRepository):
     messages: MutableSequence[Message[MyMetadata]]
 
-    def __init__(self, publisher: Optional[SyncEventstreamPublisher]):
+    def __init__(self, publisher: SyncEventstreamPublisher | None):
         super().__init__(publisher=publisher)
         self.messages = []
 
@@ -119,7 +112,7 @@ class SyncDummyEventStore(SyncEventstoreAbstractRepository):
 
 
 class SyncDummyUnitOfWorkWithEvents(SyncAbstractUnitOfWork[Repositories]):
-    def __init__(self, publisher: Optional[SyncEventstreamPublisher]) -> None:
+    def __init__(self, publisher: SyncEventstreamPublisher | None) -> None:
         self.foos = SyncFooRepository()
         self.bars = SyncDummyRepository()
         self.eventstore = SyncDummyEventStore(publisher=publisher)

--- a/tests/_sync/handlers/dummy.py
+++ b/tests/_sync/handlers/dummy.py
@@ -1,8 +1,15 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from messagebus.service._sync.registry import sync_listen
 from messagebus.service._sync.unit_of_work import SyncAbstractUnitOfWork
-from tests._sync.conftest import DummyCommand, DummyEvent
+from tests._sync.conftest import AnotherDummyCommand, DummyCommand, DummyEvent
+
+
+class Notifier:
+    inbox: ClassVar[list[str]] = []
+
+    def send_message(self, message: str):
+        self.inbox.append(message)
 
 
 @sync_listen
@@ -15,3 +22,11 @@ def handler_evt1(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any]): ...
 
 @sync_listen
 def handler_evt2(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any]): ...
+
+
+@sync_listen
+def handler_with_dependency_injection(
+    command: AnotherDummyCommand,
+    uow: SyncAbstractUnitOfWork[Any],
+    notifier: Notifier,
+): ...

--- a/tests/_sync/handlers/dummy.py
+++ b/tests/_sync/handlers/dummy.py
@@ -1,15 +1,13 @@
-from typing import Any, ClassVar
+from typing import Any
 
 from messagebus.service._sync.registry import sync_listen
 from messagebus.service._sync.unit_of_work import SyncAbstractUnitOfWork
-from tests._sync.conftest import AnotherDummyCommand, DummyCommand, DummyEvent
-
-
-class Notifier:
-    inbox: ClassVar[list[str]] = []
-
-    def send_message(self, message: str):
-        self.inbox.append(message)
+from tests._sync.conftest import (
+    AnotherDummyCommand,
+    DummyCommand,
+    DummyEvent,
+    Notifier,
+)
 
 
 @sync_listen

--- a/tests/_sync/test_dependency.py
+++ b/tests/_sync/test_dependency.py
@@ -1,0 +1,40 @@
+from messagebus.service._sync.registry import SyncMessageBus
+from messagebus.service._sync.unit_of_work import SyncUnitOfWorkTransaction
+from tests._sync.conftest import (
+    DummyCommand,
+    DummyEvent,
+    DummyModel,
+    Notifier,
+    Repositories,
+    SyncDummyUnitOfWorkWithEvents,
+    SyncEventstreamTransport,
+)
+
+
+def listen_command(
+    cmd: DummyCommand,
+    uow: SyncUnitOfWorkTransaction[Repositories],
+    notifier: Notifier,
+) -> DummyModel:
+    """This command raise an event played by the message bus."""
+    foo = DummyModel(id=cmd.id, counter=0)
+    foo.messages.append(DummyEvent(id=foo.id, increment=10))
+    uow.foos.add(foo)
+    notifier.send_message(f"Foo {cmd.id} ordered")
+    return foo
+
+
+def test_store_events_and_publish(
+    bus: SyncMessageBus[Repositories],
+    eventstream_transport: SyncEventstreamTransport,
+    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    dummy_command: DummyCommand,
+    notifier: Notifier,
+):
+    bus.add_listener(DummyCommand, listen_command)
+    with uow_with_eventstore as tuow:
+        bus.handle(dummy_command, tuow)
+        tuow.commit()
+    assert notifier.inbox == [
+        "Foo dummy_cmd ordered",
+    ]

--- a/tests/_sync/test_registry.py
+++ b/tests/_sync/test_registry.py
@@ -45,9 +45,9 @@ def test_messagebus(
 
     foo = listen_command(DummyCommand(id="foo"), tuow)
     assert list(tuow.uow.collect_new_events()) == [DummyEvent(id="foo", increment=10)]
-    assert (
-        DummyModel.counter == 0
-    ), "Events raised cannot be played before the attach_listener has been called"
+    assert DummyModel.counter == 0, (
+        "Events raised cannot be played before the attach_listener has been called"
+    )
 
     listen_event(DummyEvent(id="foo", increment=1), tuow)
     assert foo.counter == 1
@@ -67,9 +67,9 @@ def test_messagebus(
     bus.remove_listener(DummyEvent, listen_event)
 
     foo = bus.handle(DummyCommand(id="foo4"), tuow)
-    assert (
-        foo.counter == 0
-    ), "The command should raise an event that is not handled anymore "
+    assert foo.counter == 0, (
+        "The command should raise an event that is not handled anymore "
+    )
 
 
 def test_messagebus_handle_only_message(

--- a/uv.lock
+++ b/uv.lock
@@ -1,32 +1,17 @@
 version = 1
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version < '3.13'",
     "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
 name = "alabaster"
 version = "0.7.16"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.13'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511 },
-]
-
-[[package]]
-name = "alabaster"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929 },
 ]
 
 [[package]]
@@ -157,21 +142,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482", size = 144970 },
     { url = "https://files.pythonhosted.org/packages/cc/67/e5e7e0cbfefc4ca79025238b43cdf8a2037854195b37d6417f3d0895c4c2/charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67", size = 94973 },
     { url = "https://files.pythonhosted.org/packages/65/97/fc9bbc54ee13d33dc54a7fcf17b26368b18505500fc01e228c27b5222d80/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b", size = 102308 },
-    { url = "https://files.pythonhosted.org/packages/54/2f/28659eee7f5d003e0f5a3b572765bf76d6e0fe6601ab1f1b1dd4cba7e4f1/charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:980b4f289d1d90ca5efcf07958d3eb38ed9c0b7676bf2831a54d4f66f9c27dfa", size = 196326 },
-    { url = "https://files.pythonhosted.org/packages/d1/18/92869d5c0057baa973a3ee2af71573be7b084b3c3d428fe6463ce71167f8/charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f28f891ccd15c514a0981f3b9db9aa23d62fe1a99997512b0491d2ed323d229a", size = 125614 },
-    { url = "https://files.pythonhosted.org/packages/d6/27/327904c5a54a7796bb9f36810ec4173d2df5d88b401d2b95ef53111d214e/charset_normalizer-3.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8aacce6e2e1edcb6ac625fb0f8c3a9570ccc7bfba1f63419b3769ccf6a00ed0", size = 120450 },
-    { url = "https://files.pythonhosted.org/packages/a4/23/65af317914a0308495133b2d654cf67b11bbd6ca16637c4e8a38f80a5a69/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd7af3717683bea4c87acd8c0d3d5b44d56120b26fd3f8a692bdd2d5260c620a", size = 140135 },
-    { url = "https://files.pythonhosted.org/packages/f2/41/6190102ad521a8aa888519bb014a74251ac4586cde9b38e790901684f9ab/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ff2ed8194587faf56555927b3aa10e6fb69d931e33953943bc4f837dfee2242", size = 150413 },
-    { url = "https://files.pythonhosted.org/packages/7b/ab/f47b0159a69eab9bd915591106859f49670c75f9a19082505ff16f50efc0/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e91f541a85298cf35433bf66f3fab2a4a2cff05c127eeca4af174f6d497f0d4b", size = 142992 },
-    { url = "https://files.pythonhosted.org/packages/28/89/60f51ad71f63aaaa7e51a2a2ad37919985a341a1d267070f212cdf6c2d22/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309a7de0a0ff3040acaebb35ec45d18db4b28232f21998851cfa709eeff49d62", size = 144871 },
-    { url = "https://files.pythonhosted.org/packages/0c/48/0050550275fea585a6e24460b42465020b53375017d8596c96be57bfabca/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:285e96d9d53422efc0d7a17c60e59f37fbf3dfa942073f666db4ac71e8d726d0", size = 146756 },
-    { url = "https://files.pythonhosted.org/packages/dc/b5/47f8ee91455946f745e6c9ddbb0f8f50314d2416dd922b213e7d5551ad09/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5d447056e2ca60382d460a604b6302d8db69476fd2015c81e7c35417cfabe4cd", size = 141034 },
-    { url = "https://files.pythonhosted.org/packages/84/79/5c731059ebab43e80bf61fa51666b9b18167974b82004f18c76378ed31a3/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:20587d20f557fe189b7947d8e7ec5afa110ccf72a3128d61a2a387c3313f46be", size = 149434 },
-    { url = "https://files.pythonhosted.org/packages/ca/f3/0719cd09fc4dc42066f239cb3c48ced17fc3316afca3e2a30a4756fe49ab/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:130272c698667a982a5d0e626851ceff662565379baf0ff2cc58067b81d4f11d", size = 152443 },
-    { url = "https://files.pythonhosted.org/packages/f7/0e/c6357297f1157c8e8227ff337e93fd0a90e498e3d6ab96b2782204ecae48/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:ab22fbd9765e6954bc0bcff24c25ff71dcbfdb185fcdaca49e81bac68fe724d3", size = 150294 },
-    { url = "https://files.pythonhosted.org/packages/54/9a/acfa96dc4ea8c928040b15822b59d0863d6e1757fba8bd7de3dc4f761c13/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7782afc9b6b42200f7362858f9e73b1f8316afb276d316336c0ec3bd73312742", size = 145314 },
-    { url = "https://files.pythonhosted.org/packages/73/1c/b10a63032eaebb8d7bcb8544f12f063f41f5f463778ac61da15d9985e8b6/charset_normalizer-3.4.0-cp39-cp39-win32.whl", hash = "sha256:2de62e8801ddfff069cd5c504ce3bc9672b23266597d4e4f50eda28846c322f2", size = 94724 },
-    { url = "https://files.pythonhosted.org/packages/c5/77/3a78bf28bfaa0863f9cfef278dbeadf55efe064eafff8c7c424ae3c4c1bf/charset_normalizer-3.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:95c3c157765b031331dd4db3c775e58deaee050a3042fcad72cbc4189d7c8dca", size = 102159 },
     { url = "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079", size = 49446 },
 ]
 
@@ -240,16 +210,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/d9/3d820c00066ae55d69e6d0eae11d6149a5ca7546de469ba9d597f01bf2d7/coverage-7.6.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cc8ff50b50ce532de2fa7a7daae9dd12f0a699bfcd47f20945364e5c31799fef", size = 247510 },
     { url = "https://files.pythonhosted.org/packages/8f/c3/4fa1eb412bb288ff6bfcc163c11700ff06e02c5fad8513817186e460ed43/coverage-7.6.4-cp313-cp313t-win32.whl", hash = "sha256:b8d3a03d9bfcaf5b0141d07a88456bb6a4c3ce55c080712fec8418ef3610230e", size = 210353 },
     { url = "https://files.pythonhosted.org/packages/7e/77/03fc2979d1538884d921c2013075917fc927f41cd8526909852fe4494112/coverage-7.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:f3ddf056d3ebcf6ce47bdaf56142af51bb7fad09e4af310241e9db7a3a8022e1", size = 211502 },
-    { url = "https://files.pythonhosted.org/packages/fb/27/7efede2355bd1417137246246ab0980751b3ba6065102518a2d1eba6a278/coverage-7.6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9cb7fa111d21a6b55cbf633039f7bc2749e74932e3aa7cb7333f675a58a58bf3", size = 206714 },
-    { url = "https://files.pythonhosted.org/packages/f3/94/594af55226676d078af72b329372e2d036f9ba1eb6bcf1f81debea2453c7/coverage-7.6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:11a223a14e91a4693d2d0755c7a043db43d96a7450b4f356d506c2562c48642c", size = 207146 },
-    { url = "https://files.pythonhosted.org/packages/d5/13/19de1c5315b22795dd67dbd9168281632424a344b648d23d146572e42c2b/coverage-7.6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a413a096c4cbac202433c850ee43fa326d2e871b24554da8327b01632673a076", size = 235180 },
-    { url = "https://files.pythonhosted.org/packages/db/26/8fba01ce9f376708c7efed2761cea740f50a1b4138551886213797a4cecd/coverage-7.6.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00a1d69c112ff5149cabe60d2e2ee948752c975d95f1e1096742e6077affd376", size = 233100 },
-    { url = "https://files.pythonhosted.org/packages/74/66/4db60266551b89e820b457bc3811a3c5eaad3c1324cef7730c468633387a/coverage-7.6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f76846299ba5c54d12c91d776d9605ae33f8ae2b9d1d3c3703cf2db1a67f2c0", size = 234231 },
-    { url = "https://files.pythonhosted.org/packages/2a/9b/7b33f0892fccce50fc82ad8da76c7af1731aea48ec71279eef63a9522db7/coverage-7.6.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fe439416eb6380de434886b00c859304338f8b19f6f54811984f3420a2e03858", size = 233383 },
-    { url = "https://files.pythonhosted.org/packages/91/49/6ff9c4e8a67d9014e1c434566e9169965f970350f4792a0246cd0d839442/coverage-7.6.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0294ca37f1ba500667b1aef631e48d875ced93ad5e06fa665a3295bdd1d95111", size = 231863 },
-    { url = "https://files.pythonhosted.org/packages/81/f9/c9d330dec440676b91504fcceebca0814718fa71c8498cf29d4e21e9dbfc/coverage-7.6.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6f01ba56b1c0e9d149f9ac85a2f999724895229eb36bd997b61e62999e9b0901", size = 232854 },
-    { url = "https://files.pythonhosted.org/packages/ee/d9/605517a023a0ba8eb1f30d958f0a7ff3a21867b07dcb42618f862695ca0e/coverage-7.6.4-cp39-cp39-win32.whl", hash = "sha256:bc66f0bf1d7730a17430a50163bb264ba9ded56739112368ba985ddaa9c3bd09", size = 209437 },
-    { url = "https://files.pythonhosted.org/packages/aa/79/2626903efa84e9f5b9c8ee6972de8338673fdb5bb8d8d2797740bf911027/coverage-7.6.4-cp39-cp39-win_amd64.whl", hash = "sha256:c481b47f6b5845064c65a7bc78bc0860e635a9b055af0df46fdf1c58cebf8e8f", size = 210209 },
     { url = "https://files.pythonhosted.org/packages/cc/56/e1d75e8981a2a92c2a777e67c26efa96c66da59d645423146eb9ff3a851b/coverage-7.6.4-pp39.pp310-none-any.whl", hash = "sha256:3c65d37f3a9ebb703e710befdc489a38683a5b152242664b973a7b7b22348a4e", size = 198954 },
 ]
 
@@ -275,8 +235,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pygls" },
     { name = "pyspellchecker" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/c5/0c89af3da1f3133b53f3ba8ae677ed4d4ddff33eec50dbf32c95e01ed2d2/esbonio-0.16.5.tar.gz", hash = "sha256:acab2e16c6cf8f7232fb04e0d48514ce50566516b1f6fcf669ccf2f247e8b10f", size = 145347 }
 wheels = [
@@ -299,8 +258,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
     { name = "sphinx-basic-ng" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/e2/d351d69a9a9e4badb4a5be062c2d0e87bd9e6c23b5e57337fef14bef34c8/furo-2024.8.6.tar.gz", hash = "sha256:b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01", size = 1661506 }
@@ -324,18 +282,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769 },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514 },
 ]
 
 [[package]]
@@ -411,17 +357,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/ed/9e074a23aa5ecf199cd4a5056b61a123f97cf6a12bd13b1eceae01ad8373/lastuuid-0.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:03d526fb839774ba9018adcd7cb21d4f9b7434e3a361d111e88b46a76f309eb4", size = 394803 },
     { url = "https://files.pythonhosted.org/packages/6a/d3/8201fca78ef1b915dd0dc9e7ace26943049468469c2ecdcf0b401c90a1d5/lastuuid-0.1.1-cp313-none-win32.whl", hash = "sha256:bd60b7695a39c0b328f8d6d37bdaa54d54643217220e5384307b6b9e12dc1391", size = 92299 },
     { url = "https://files.pythonhosted.org/packages/c7/3b/1cfbc63088642ca2cbed730c155ef0636fec7d37292b467267fc4657c4bc/lastuuid-0.1.1-cp313-none-win_amd64.whl", hash = "sha256:9ae3f754a033aae958cf9e54560390ee67542d74d14ddac82327d8bd2ddb2d6b", size = 100704 },
-    { url = "https://files.pythonhosted.org/packages/4a/21/951500dbc034b3bbcd03d71b05938f7a295cd6cbab3973b321d0837566dc/lastuuid-0.1.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:1750d67f2c77f41127cab9ada97db5ff740605467e703d30dd2d85feb3520d1e", size = 200064 },
-    { url = "https://files.pythonhosted.org/packages/5f/34/e1f0ad20da5e2366b36348b825ad434bdbdd063e624142ed61e9d3de5e65/lastuuid-0.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1e473d97823d1eec801d8d8309f8f736add4c725bf04d8cdd52529ae2369d570", size = 195352 },
-    { url = "https://files.pythonhosted.org/packages/66/38/ced06c2264265fbed9259b44a2709b1f262ebfdee1998336023938259901/lastuuid-0.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09443643e8ec01a313adf47b7c738dcfe0b496373d19488b7e8ca4531424dbc1", size = 225918 },
-    { url = "https://files.pythonhosted.org/packages/82/e4/4f0a317acb7e55f9c3ff12592fee364e17082dd1a99f02205aa198783a27/lastuuid-0.1.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d37538e7f9a9a1a5a7fe96f88835afcb8b834a652136999c2b5bb3a79b4042b", size = 231255 },
-    { url = "https://files.pythonhosted.org/packages/12/40/5b58026c6c9b3a53f3dc39544ed7452b9472b29d6f8d72c3052c17ef10a5/lastuuid-0.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8212d3de0243e53c1475cfe4c5556602221791dd3294f293261d86100f0eb6a1", size = 265247 },
-    { url = "https://files.pythonhosted.org/packages/c9/cf/e97e26b73a548c927194ff35c26f44f1d8d86215e1c27da8d89fc85fb90c/lastuuid-0.1.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a13069ed5867ca480ac6a0abf016d6942cafae70c3436a1e37de9b19843a9dd", size = 264136 },
-    { url = "https://files.pythonhosted.org/packages/fb/42/88433a9d6d7b0910561cd0c1ba6407f4ff06fb99af33786168aaaaa1f1b7/lastuuid-0.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2a631845ae411577a929c6ede376ec572943cdf917630337b652935d9c05e49", size = 227682 },
-    { url = "https://files.pythonhosted.org/packages/78/6c/7f8c425989bc223efa100a395f2e0f5e95e27bc4223803dab9cef521542d/lastuuid-0.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:480ff2af38aaa891cccba7dad997bec2f05d6ecd901055d64cd7bf50cb1ffa77", size = 237781 },
-    { url = "https://files.pythonhosted.org/packages/ac/11/ad6e409c9c3695cd7eaa9bb3f410205509b1ab67d2589e7bbf775ffd1d47/lastuuid-0.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:180c5dd4d48bfd52db1106e0d7d646ad9c93973dca9287b02288face4e00f3ab", size = 409657 },
-    { url = "https://files.pythonhosted.org/packages/f3/1e/2dbbeaf6f935fb63cc97c8c642e6d18ac4c482dd0278019cde49c6eb88b7/lastuuid-0.1.1-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:7daef4069838845d9f871a3e41fe5d93595b65e2e635c559fcb6b13a3bad9b09", size = 489909 },
-    { url = "https://files.pythonhosted.org/packages/d9/a0/6bd472d243e17cdd44015b6f8543cb471b949c7a1cba571dbd17c58740a5/lastuuid-0.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:372e149c3b293cb9f0d71bd7c4d6fcfdf667692e9a7333e1abede621eb0ec4d3", size = 395296 },
     { url = "https://files.pythonhosted.org/packages/c6/c2/b381930dcdc571b4e914c2c7412f571fc0ae4a82176a4e76cd792997fff4/lastuuid-0.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:932df0652c0072b58e5563d3bab037a0018e387fa997a43f65d0c868771f27fc", size = 200110 },
     { url = "https://files.pythonhosted.org/packages/ca/f8/c6d64ee48c4b665b6c1e4be389fd56eac1ad593511cc427c394a5519ed89/lastuuid-0.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:7bd4fe91a6cf00fbca3de30acc2ff57a0fbbccbcdd93950d19cb26dd06930e36", size = 195862 },
     { url = "https://files.pythonhosted.org/packages/d8/95/2a90fa573b011e49219609a802ee3cdf7612a5fd87eecdbfa3218f1e9aa5/lastuuid-0.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07e80750ef46b6648afe8a360c87523569b5986bd7122dc5fa080acaceac8d6", size = 226170 },
@@ -430,14 +365,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/63/4088a8b5930a80af64c9ecce52b8a525b8475d0c2d51599f0d301ad0440e/lastuuid-0.1.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f8bf93ca85179788508403a4030bb894581b9c8970cc6462533aab6288154d4e", size = 410841 },
     { url = "https://files.pythonhosted.org/packages/90/df/f852cbe34dab1d40afc73e2f910315e7578cbce9e3f1342e31259650896b/lastuuid-0.1.1-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:96889a2dc8ea442e3010be9d01ec26560e899ff1a5effc54ff70a1b81c97010d", size = 490478 },
     { url = "https://files.pythonhosted.org/packages/5a/6b/2ff645155d42afa54f617b3034b1de88a2cf3106c098875a3b0136910404/lastuuid-0.1.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:c22e25874ff33d9d013a49456f1bcb666f64ab1a7487c301c4554381d2a1adac", size = 395934 },
-    { url = "https://files.pythonhosted.org/packages/1c/8b/5492db0e8e5fc687fbcdc8d740fba427e28bb8a475f3494eb82d27705a2c/lastuuid-0.1.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dda1b50d399b6bbcbdf3bdf126a1522f56776205b168a1de9363cbe24147885f", size = 200139 },
-    { url = "https://files.pythonhosted.org/packages/f5/47/64004d5fcc7b21302dbcc66495b2f984f88facb1cc81f82de6245b562e73/lastuuid-0.1.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:510ce4ddafeeecb1acd1f34ed482d556dfe11a256660fadcad334176816bb7cc", size = 195949 },
-    { url = "https://files.pythonhosted.org/packages/a3/6d/34c9591acc054d85b1b76667895c699a9dd70d0403fdd02d43ec578bf666/lastuuid-0.1.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1863bf112993a3f9517bebf8d7e183596ba872bd552b569e947aada436192af", size = 226413 },
-    { url = "https://files.pythonhosted.org/packages/2f/39/3d372f4abb2795581c4e877f46e3d6f4932a8c2e073d2223fc371bc33da4/lastuuid-0.1.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6552d29deec284da23bd870b12da31d6daac9ce41e8a50be28b1c73145afc1a", size = 228352 },
-    { url = "https://files.pythonhosted.org/packages/87/7d/2a319c757d7fc09e694be8d4ae23810b659ab01d8690451cdfd0d00172ac/lastuuid-0.1.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bff8a06cdd3bda06f4851d05519897c31c9de72b964fdb6c6694fac119721706", size = 237997 },
-    { url = "https://files.pythonhosted.org/packages/b3/64/ad3732a23b8a5582092122f3e6abbefa45be137152015dce38c9f49dcf6d/lastuuid-0.1.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3102c884cf1354419873482502fc139764f76153ae53df16567718c5f9f45a8b", size = 410979 },
-    { url = "https://files.pythonhosted.org/packages/a9/af/4322bc59a8d9f99e20fcec0109a62497d6d38f85c27a41f15aa0173d6f5e/lastuuid-0.1.1-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:913d28bc74360166ca8d403e94ff9a9d4dfd53ec7612190923183707f81bd2f9", size = 490508 },
-    { url = "https://files.pythonhosted.org/packages/77/54/874716bc5d8e708d8b746ac8d4cb34fed261a74ca3ea8278bc4242af9fab/lastuuid-0.1.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0e3c597bd5a6cd5e9d7923f4e941b917be79c3dfda5ea53e2780a6bd03816ce", size = 396018 },
 ]
 
 [[package]]
@@ -509,16 +436,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
-    { url = "https://files.pythonhosted.org/packages/a7/ea/9b1530c3fdeeca613faeb0fb5cbcf2389d816072fab72a71b45749ef6062/MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a", size = 14344 },
-    { url = "https://files.pythonhosted.org/packages/4b/c2/fbdbfe48848e7112ab05e627e718e854d20192b674952d9042ebd8c9e5de/MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff", size = 12389 },
-    { url = "https://files.pythonhosted.org/packages/f0/25/7a7c6e4dbd4f867d95d94ca15449e91e52856f6ed1905d58ef1de5e211d0/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13", size = 21607 },
-    { url = "https://files.pythonhosted.org/packages/53/8f/f339c98a178f3c1e545622206b40986a4c3307fe39f70ccd3d9df9a9e425/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144", size = 20728 },
-    { url = "https://files.pythonhosted.org/packages/1a/03/8496a1a78308456dbd50b23a385c69b41f2e9661c67ea1329849a598a8f9/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29", size = 20826 },
-    { url = "https://files.pythonhosted.org/packages/e6/cf/0a490a4bd363048c3022f2f475c8c05582179bb179defcee4766fb3dcc18/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0", size = 21843 },
-    { url = "https://files.pythonhosted.org/packages/19/a3/34187a78613920dfd3cdf68ef6ce5e99c4f3417f035694074beb8848cd77/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0", size = 21219 },
-    { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946 },
-    { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063 },
-    { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506 },
 ]
 
 [[package]]
@@ -534,8 +451,7 @@ dependencies = [
 [package.optional-dependencies]
 docs = [
     { name = "furo" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
 ]
 
@@ -551,8 +467,7 @@ dev = [
 doc = [
     { name = "esbonio" },
     { name = "furo" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
 ]
 
@@ -613,11 +528,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/1f/6b76be289a5a521bb1caedc1f08e76ff17ab59061007f201a8a18cc514d1/mypy-1.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2904956dac40ced10931ac967ae63c5089bd498542194b436eb097a9f77bc8", size = 12584043 },
     { url = "https://files.pythonhosted.org/packages/a6/83/5a85c9a5976c6f96e3a5a7591aa28b4a6ca3a07e9e5ba0cec090c8b596d6/mypy-1.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7bfd8836970d33c2105562650656b6846149374dc8ed77d98424b40b09340ba7", size = 13036996 },
     { url = "https://files.pythonhosted.org/packages/b4/59/c39a6f752f1f893fccbcf1bdd2aca67c79c842402b5283563d006a67cf76/mypy-1.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9f73dba9ec77acb86457a8fc04b5239822df0c14a082564737833d2963677dbc", size = 9737709 },
-    { url = "https://files.pythonhosted.org/packages/5f/d4/b33ddd40dad230efb317898a2d1c267c04edba73bc5086bf77edeb410fb2/mypy-1.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0246bcb1b5de7f08f2826451abd947bf656945209b140d16ed317f65a17dc7dc", size = 11013906 },
-    { url = "https://files.pythonhosted.org/packages/f4/e6/f414bca465b44d01cd5f4a82761e15044bedd1bf8025c5af3cc64518fac5/mypy-1.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f5b7deae912cf8b77e990b9280f170381fdfbddf61b4ef80927edd813163732", size = 10180657 },
-    { url = "https://files.pythonhosted.org/packages/38/e9/fc3865e417722f98d58409770be01afb961e2c1f99930659ff4ae7ca8b7e/mypy-1.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7029881ec6ffb8bc233a4fa364736789582c738217b133f1b55967115288a2bc", size = 12586394 },
-    { url = "https://files.pythonhosted.org/packages/2e/35/f4d8b6d2cb0b3dad63e96caf159419dda023f45a358c6c9ac582ccaee354/mypy-1.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3e38b980e5681f28f033f3be86b099a247b13c491f14bb8b1e1e134d23bb599d", size = 13103591 },
-    { url = "https://files.pythonhosted.org/packages/22/1d/80594aef135f921dd52e142fa0acd19df197690bd0cde42cea7b88cf5aa2/mypy-1.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:a6789be98a2017c912ae6ccb77ea553bbaf13d27605d2ca20a76dfbced631b24", size = 9634690 },
     { url = "https://files.pythonhosted.org/packages/3b/86/72ce7f57431d87a7ff17d442f521146a6585019eb8f4f31b7c02801f78ad/mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a", size = 2647043 },
 ]
 
@@ -728,18 +638,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
     { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
     { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
-    { url = "https://files.pythonhosted.org/packages/7a/04/2580b2deaae37b3e30fc30c54298be938b973990b23612d6b61c7bdd01c7/pydantic_core-2.23.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a4fa4fc04dff799089689f4fd502ce7d59de529fc2f40a2c8836886c03e0175a", size = 1868200 },
-    { url = "https://files.pythonhosted.org/packages/39/6e/e311bd0751505350f0cdcee3077841eb1f9253c5a1ddbad048cd9fbf7c6e/pydantic_core-2.23.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a7df63886be5e270da67e0966cf4afbae86069501d35c8c1b3b6c168f42cb36", size = 1749316 },
-    { url = "https://files.pythonhosted.org/packages/d0/b4/95b5eb47c6dc8692508c3ca04a1f8d6f0884c9dacb34cf3357595cbe73be/pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcedcd19a557e182628afa1d553c3895a9f825b936415d0dbd3cd0bbcfd29b4b", size = 1800880 },
-    { url = "https://files.pythonhosted.org/packages/da/79/41c4f817acd7f42d94cd1e16526c062a7b089f66faed4bd30852314d9a66/pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f54b118ce5de9ac21c363d9b3caa6c800341e8c47a508787e5868c6b79c9323", size = 1807077 },
-    { url = "https://files.pythonhosted.org/packages/fb/53/d13d1eb0a97d5c06cf7a225935d471e9c241afd389a333f40c703f214973/pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86d2f57d3e1379a9525c5ab067b27dbb8a0642fb5d454e17a9ac434f9ce523e3", size = 2002859 },
-    { url = "https://files.pythonhosted.org/packages/53/7d/6b8a1eff453774b46cac8c849e99455b27167971a003212f668e94bc4c9c/pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de6d1d1b9e5101508cb37ab0d972357cac5235f5c6533d1071964c47139257df", size = 2661437 },
-    { url = "https://files.pythonhosted.org/packages/6c/ea/8820f57f0b46e6148ee42d8216b15e8fe3b360944284bbc705bf34fac888/pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1278e0d324f6908e872730c9102b0112477a7f7cf88b308e4fc36ce1bdb6d58c", size = 2054404 },
-    { url = "https://files.pythonhosted.org/packages/0f/36/d4ae869e473c3c7868e1cd1e2a1b9e13bce5cd1a7d287f6ac755a0b1575e/pydantic_core-2.23.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a6b5099eeec78827553827f4c6b8615978bb4b6a88e5d9b93eddf8bb6790f55", size = 1921680 },
-    { url = "https://files.pythonhosted.org/packages/0d/f8/eed5c65b80c4ac4494117e2101973b45fc655774ef647d17dde40a70f7d2/pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e55541f756f9b3ee346b840103f32779c695a19826a4c442b7954550a0972040", size = 1966093 },
-    { url = "https://files.pythonhosted.org/packages/e8/c8/1d42ce51d65e571ab53d466cae83434325a126811df7ce4861d9d97bee4b/pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a5c7ba8ffb6d6f8f2ab08743be203654bb1aaa8c9dcb09f82ddd34eadb695605", size = 2111437 },
-    { url = "https://files.pythonhosted.org/packages/aa/c9/7fea9d13383c2ec6865919e09cffe44ab77e911eb281b53a4deaafd4c8e8/pydantic_core-2.23.4-cp39-none-win32.whl", hash = "sha256:37b0fe330e4a58d3c58b24d91d1eb102aeec675a3db4c292ec3928ecd892a9a6", size = 1735049 },
-    { url = "https://files.pythonhosted.org/packages/98/95/dd7045c4caa2b73d0bf3b989d66b23cfbb7a0ef14ce99db15677a000a953/pydantic_core-2.23.4-cp39-none-win_amd64.whl", hash = "sha256:1498bec4c05c9c787bde9125cfdcc63a41004ff167f495063191b863399b1a29", size = 1920180 },
     { url = "https://files.pythonhosted.org/packages/13/a9/5d582eb3204464284611f636b55c0a7410d748ff338756323cb1ce721b96/pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f455ee30a9d61d3e1a15abd5068827773d6e4dc513e795f380cdd59932c782d5", size = 1857135 },
     { url = "https://files.pythonhosted.org/packages/2c/57/faf36290933fe16717f97829eabfb1868182ac495f99cf0eda9f59687c9d/pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1e90d2e3bd2c3863d48525d297cd143fe541be8bbf6f579504b9712cb6b643ec", size = 1740583 },
     { url = "https://files.pythonhosted.org/packages/91/7c/d99e3513dc191c4fec363aef1bf4c8af9125d8fa53af7cb97e8babef4e40/pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e203fdf807ac7e12ab59ca2bfcabb38c7cf0b33c41efeb00f8e5da1d86af480", size = 1793637 },
@@ -748,14 +646,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ca/9c0854829311fb446020ebb540ee22509731abad886d2859c855dd29b904/pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d06b0c8da4f16d1d1e352134427cb194a0a6e19ad5db9161bf32b2113409e728", size = 1957926 },
     { url = "https://files.pythonhosted.org/packages/c0/1c/7836b67c42d0cd4441fcd9fafbf6a027ad4b79b6559f80cf11f89fd83648/pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:ba1a0996f6c2773bd83e63f18914c1de3c9dd26d55f4ac302a7efe93fb8e7433", size = 2100342 },
     { url = "https://files.pythonhosted.org/packages/a9/f9/b6bcaf874f410564a78908739c80861a171788ef4d4f76f5009656672dfe/pydantic_core-2.23.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:9a5bce9d23aac8f0cf0836ecfc033896aa8443b501c58d0602dbfd5bd5b37753", size = 1920344 },
-    { url = "https://files.pythonhosted.org/packages/32/fd/ac9cdfaaa7cf2d32590b807d900612b39acb25e5527c3c7e482f0553025b/pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:78ddaaa81421a29574a682b3179d4cf9e6d405a09b99d93ddcf7e5239c742e21", size = 1857850 },
-    { url = "https://files.pythonhosted.org/packages/08/fe/038f4b2bcae325ea643c8ad353191187a4c92a9c3b913b139289a6f2ef04/pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:883a91b5dd7d26492ff2f04f40fbb652de40fcc0afe07e8129e8ae779c2110eb", size = 1740265 },
-    { url = "https://files.pythonhosted.org/packages/51/14/b215c9c3cbd1edaaea23014d4b3304260823f712d3fdee52549b19b25d62/pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88ad334a15b32a791ea935af224b9de1bf99bcd62fabf745d5f3442199d86d59", size = 1793912 },
-    { url = "https://files.pythonhosted.org/packages/62/de/2c3ad79b63ba564878cbce325be725929ba50089cd5156f89ea5155cb9b3/pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:233710f069d251feb12a56da21e14cca67994eab08362207785cf8c598e74577", size = 1942870 },
-    { url = "https://files.pythonhosted.org/packages/cb/55/c222af19e4644c741b3f3fe4fd8bbb6b4cdca87d8a49258b61cf7826b19e/pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:19442362866a753485ba5e4be408964644dd6a09123d9416c54cd49171f50744", size = 1915610 },
-    { url = "https://files.pythonhosted.org/packages/c4/7a/9a8760692a6f76bb54bcd43f245ff3d8b603db695899bbc624099c00af80/pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:624e278a7d29b6445e4e813af92af37820fafb6dcc55c012c834f9e26f9aaaef", size = 1958403 },
-    { url = "https://files.pythonhosted.org/packages/4c/91/9b03166feb914bb5698e2f6499e07c2617e2eebf69f9374d0358d7eb2009/pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f5ef8f42bec47f21d07668a043f077d507e5bf4e668d5c6dfe6aaba89de1a5b8", size = 2101154 },
-    { url = "https://files.pythonhosted.org/packages/1d/d9/1d7ecb98318da4cb96986daaf0e20d66f1651d0aeb9e2d4435b916ce031d/pydantic_core-2.23.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:aea443fffa9fbe3af1a9ba721a87f926fe548d32cab71d188a6ede77d0ff244e", size = 1920855 },
 ]
 
 [[package]]
@@ -850,9 +740,6 @@ wheels = [
 name = "result"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/47/2175be65744aa4d8419c27bd3a7a7d65af5bcad7a4dc6a812c00778754f0/result-0.17.0.tar.gz", hash = "sha256:b73da420c0cb1a3bf741dbd41ff96dedafaad6a1b3ef437a9e33e380bb0d91cf", size = 20180 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/90/19110ce9374c3db619e2df0816f2c58e4ddc5cdad5f7284cd81d8b30b7cb/result-0.17.0-py3-none-any.whl", hash = "sha256:49fd668b4951ad15800b8ccefd98b6b94effc789607e19c65064b775570933e8", size = 11689 },
@@ -889,27 +776,23 @@ wheels = [
 name = "sphinx"
 version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "babel", marker = "python_full_version < '3.13'" },
-    { name = "colorama", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.13'" },
-    { name = "imagesize", marker = "python_full_version < '3.13'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.13'" },
-    { name = "packaging", marker = "python_full_version < '3.13'" },
-    { name = "pygments", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.13'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.13'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911 }
@@ -918,42 +801,11 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx"
-version = "8.1.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-]
-dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "babel", marker = "python_full_version >= '3.13'" },
-    { name = "colorama", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.13'" },
-    { name = "imagesize", marker = "python_full_version >= '3.13'" },
-    { name = "jinja2", marker = "python_full_version >= '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.13'" },
-    { name = "pygments", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.13'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125 },
-]
-
-[[package]]
 name = "sphinx-autodoc-typehints"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/19/1131e37f815864efbdb6498cc41f5ce3da82b7e952456900968132c7dcba/sphinx_autodoc_typehints-1.25.3.tar.gz", hash = "sha256:70db10b391acf4e772019765991d2de0ff30ec0899b9ba137706dc0b3c4835e0", size = 37709 }
 wheels = [
@@ -965,8 +817,7 @@ name = "sphinx-basic-ng"
 version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736 }
 wheels = [
@@ -1083,13 +934,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/39/7c0d9011ec465951aaf71c252effc7c031a04404887422c6f66ba26500e1/venusian-3.1.0.tar.gz", hash = "sha256:eb72cdca6f3139a15dc80f9c95d3c10f8a54a0ba881eeef8e2ec5b42d3ee3a95", size = 37960 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/d7/36860f68eb977ad685d0f0fda733eca913dbda1bb29bbc5f1c5ba460201a/venusian-3.1.0-py3-none-any.whl", hash = "sha256:d1fb1e49927f42573f6c9b7c4fcf61c892af8fdcaa2314daa01d9a560b23488d", size = 13987 },
-]
-
-[[package]]
-name = "zipp"
-version = "3.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200 },
 ]


### PR DESCRIPTION
Adding optional extra dependency to the message bus.

I remove python 3.9 compatibility here, mainly for typing reason.

I don't document the feature yet before using it in a real world example,
I am not sure, having lifetime issue with the dependencies.

We can now create something like this:

```
bus = AsyncMessageBus(notifier=EmailNotifier())
```

and then inject a notifier kwargs on a listener, such as,


```
@async_listen
async def handler_with_dependency_injection(
    command: AnotherDummyCommand,
    uow: AsyncAbstractUnitOfWork[Any],
    notifier: AbstractNotifier,
): ...
```

Every kwargs of the bus can be set to async handler and are injected during the call.
The parameter name is used to match the dependency name.