### PR TITLE
Refactor to isolate dependencies per transaction

### DIFF
--- a/src/messagebus/domain/model/message.py
+++ b/src/messagebus/domain/model/message.py
@@ -6,7 +6,7 @@ Message base classes.
 """
 
 from datetime import datetime
-from typing import Any, Generic
+from typing import Any, Generic, TypeVar
 from uuid import UUID
 
 from lastuuid import uuid7
@@ -69,3 +69,6 @@ Command = GenericCommand[Metadata]
 """Command that use the default metadata."""
 Event = GenericEvent[Metadata]
 """Event that use the default metadata."""
+
+
+TMessage = TypeVar("TMessage", bound=Message[Any])

--- a/src/messagebus/service/_async/dependency.py
+++ b/src/messagebus/service/_async/dependency.py
@@ -1,0 +1,39 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, Generic
+
+from messagebus.domain.model.message import TMessage
+from messagebus.service._async.unit_of_work import TAsyncUow
+from messagebus.typing import AsyncMessageHandler, P
+
+
+class AsyncDependency:
+    """Describe an async dependency"""
+
+    async def on_after_commit(self) -> None:
+        """Method called when the unit of work transaction is has been commited."""
+
+    async def on_after_rollback(self) -> None:
+        """Method called when the unit of work transaction is has been rolled back."""
+
+
+class AsyncMessageHook(Generic[TMessage, TAsyncUow, P]):
+    callback: AsyncMessageHandler[TMessage, "TAsyncUow", P]
+    dependencies: Sequence[str]
+
+    def __init__(
+        self,
+        callback: AsyncMessageHandler[TMessage, "TAsyncUow", P],
+        dependencies: Sequence[str],
+    ) -> None:
+        self.callback = callback
+        self.dependencies = dependencies
+
+    async def __call__(
+        self,
+        msg: TMessage,
+        uow: "TAsyncUow",
+        dependencies: Mapping[str, AsyncDependency],
+    ) -> Any:
+        deps = {k: dependencies[k] for k in self.dependencies}
+        resp = await self.callback(msg, uow, **deps)  # type: ignore
+        return resp

--- a/src/messagebus/service/_sync/dependency.py
+++ b/src/messagebus/service/_sync/dependency.py
@@ -1,0 +1,39 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, Generic
+
+from messagebus.domain.model.message import TMessage
+from messagebus.service._sync.unit_of_work import TSyncUow
+from messagebus.typing import P, SyncMessageHandler
+
+
+class SyncDependency:
+    """Describe an async dependency"""
+
+    def on_after_commit(self) -> None:
+        """Method called when the unit of work transaction is has been commited."""
+
+    def on_after_rollback(self) -> None:
+        """Method called when the unit of work transaction is has been rolled back."""
+
+
+class SyncMessageHook(Generic[TMessage, TSyncUow, P]):
+    callback: SyncMessageHandler[TMessage, "TSyncUow", P]
+    dependencies: Sequence[str]
+
+    def __init__(
+        self,
+        callback: SyncMessageHandler[TMessage, "TSyncUow", P],
+        dependencies: Sequence[str],
+    ) -> None:
+        self.callback = callback
+        self.dependencies = dependencies
+
+    def __call__(
+        self,
+        msg: TMessage,
+        uow: "TSyncUow",
+        dependencies: Mapping[str, SyncDependency],
+    ) -> Any:
+        deps = {k: dependencies[k] for k in self.dependencies}
+        resp = self.callback(msg, uow, **deps)  # type: ignore
+        return resp

--- a/tests/_async/conftest.py
+++ b/tests/_async/conftest.py
@@ -17,6 +17,7 @@ from messagebus.domain.model import (
     Message,
     Metadata,
 )
+from messagebus.service._async.dependency import AsyncDependency
 from messagebus.service._async.eventstream import (
     AsyncAbstractEventstreamTransport,
     AsyncEventstreamPublisher,
@@ -46,7 +47,7 @@ class DummyModel(GenericModel[MyMetadata]):
     counter: int = Field(0)
 
 
-class Notifier:
+class Notifier(AsyncDependency):
     inbox: ClassVar[list[str]] = []
 
     def send_message(self, message: str):
@@ -208,11 +209,11 @@ async def uow_with_eventstore(
 
 @pytest.fixture
 def notifier():
-    return Notifier()
+    return Notifier
 
 
 @pytest.fixture
-def bus(notifier: Notifier) -> AsyncMessageBus[Repositories]:
+def bus(notifier: type[Notifier]) -> AsyncMessageBus[Repositories]:
     return AsyncMessageBus(notifier=notifier)
 
 

--- a/tests/_sync/conftest.py
+++ b/tests/_sync/conftest.py
@@ -17,6 +17,7 @@ from messagebus.domain.model import (
     Message,
     Metadata,
 )
+from messagebus.service._sync.dependency import SyncDependency
 from messagebus.service._sync.eventstream import (
     SyncAbstractEventstreamTransport,
     SyncEventstreamPublisher,
@@ -46,7 +47,7 @@ class DummyModel(GenericModel[MyMetadata]):
     counter: int = Field(0)
 
 
-class Notifier:
+class Notifier(SyncDependency):
     inbox: ClassVar[list[str]] = []
 
     def send_message(self, message: str):
@@ -208,11 +209,11 @@ def uow_with_eventstore(
 
 @pytest.fixture
 def notifier():
-    return Notifier()
+    return Notifier
 
 
 @pytest.fixture
-def bus(notifier: Notifier) -> SyncMessageBus[Repositories]:
+def bus(notifier: type[Notifier]) -> SyncMessageBus[Repositories]:
     return SyncMessageBus(notifier=notifier)
 
 


### PR DESCRIPTION
The first implementation of dependencies was not properly handle transaction.

for a notification by email perspective, we have to send the email  when the transaction is commited,

so the on_after_commit of an object instanciated while handling a command is necessary.