### PR TITLE
Features messagestore

### DIFF
--- a/docs/source/user/cookbook/06-eventstream.rst
+++ b/docs/source/user/cookbook/06-eventstream.rst
@@ -44,11 +44,11 @@ At that moment, have to implement the transport in our conftest.py file
 .. literalinclude:: 06_eventstream_03.py
    :emphasize-lines: 23,61-63,82-84,88-89
 
-First, we create an Eventstream Transport that store events in a list, and expose it as
-a fixture. The transport is also configured to override the ``eventstore`` property
-of the unit of work. We reuse the ``AsyncSinkholeEventstoreRepository`` repository.
+First, we create an Eventstream Transport that store messages in a list, and expose it
+as a fixture. The transport is also configured to override the ``messagestore`` property
+of the unit of work. We reuse the ``AsyncSinkholeMessageStoreRepository`` repository.
 which means that we don't store the events locally, but, we set up our transport,
-having the effect of sending published events to the eventstream. 
+having the effect of sending published events to the eventstream.
 
 Now lets update the code of the service handler to raise the event:
 

--- a/docs/source/user/cookbook/06_eventstream_03.py
+++ b/docs/source/user/cookbook/06_eventstream_03.py
@@ -19,7 +19,7 @@ from messagebus import (
     AsyncAbstractEventstreamTransport,
     AsyncEventstreamPublisher,
     AsyncMessageBus,
-    AsyncSinkholeEventstoreRepository,
+    AsyncSinkholeMessageStoreRepository,
 )
 
 
@@ -61,7 +61,7 @@ class InMemoryBookRepository(AbstractBookRepository):
 class InMemoryUnitOfWork(AbstractUnitOfWork):
     def __init__(self, transport: AsyncAbstractEventstreamTransport):
         self.books = InMemoryBookRepository()
-        self.eventstore = AsyncSinkholeEventstoreRepository(
+        self.messagestore = AsyncSinkholeMessageStoreRepository(
             publisher=AsyncEventstreamPublisher(transport)
         )
 

--- a/docs/source/user/cookbook/07-local-messagestore.rst
+++ b/docs/source/user/cookbook/07-local-messagestore.rst
@@ -3,7 +3,7 @@ Local event store
 
 Usually, an event store centralize all the message published by many services.
 
-An eventstore has a backend that subscribe all services eventstream and store them
+An messagestore has a backend that subscribe all services eventstream and store them
 in a database in order to replay them.
 The local event store, I don't know if the event source world has a better name for it,
 is all the message that the bus handle. event the non ``published`` flagged ones.
@@ -12,34 +12,34 @@ The message bus can store them in an event repository, usually a sql table in a
 sql based repository.
 
 For the moment, we will replace the default repository (
-:class:`messagebus.AsyncSinkholeEventstoreRepository` in previous chapter)
+:class:`messagebus.AsyncSinkholeMessageStoreRepository` in previous chapter)
 and write our own one that store them in memory.
 
-An ``EventstoreRepository`` is a :term:`repository` for all the local events,
-its override the :class:`messagebus.AsyncEventstoreAbstractRepository`.
-Only the abstract method :meth:`messagebus.AsyncEventstoreAbstractRepository._add`
+An ``MessageStoreRepository`` is a :term:`repository` for all the local events,
+its override the :class:`messagebus.AsyncMessageStoreAbstractRepository`.
+Only the abstract method :meth:`messagebus.AsyncMessageStoreAbstractRepository._add`
 needs to be implemented.
 
 
-Lets just add this in our ``conftest.py`` file in order to get an eventstore.
+Lets just add this in our ``conftest.py`` file in order to get a messagestore.
 
-.. literalinclude:: 07_local_eventstore_01.py
+.. literalinclude:: 07_local_messagestore_01.py
 
 
-Now we can update our :term:`Unit Of Work` in order to use our eventstore implementation.
+Now we can update our :term:`Unit Of Work` in order to use our messagestore implementation.
 
-.. literalinclude:: 07_local_eventstore_02.py
+.. literalinclude:: 07_local_messagestore_02.py
 
 Finally, we can update the tests to ensure that the message is stored.
 
-.. literalinclude:: 07_local_eventstore_03.py
+.. literalinclude:: 07_local_messagestore_03.py
 
 Note that there is now way to retrieve message from a
-:class:`messagebus.AsyncEventstoreAbstractRepository`.
+:class:`messagebus.AsyncMessageStoreAbstractRepository`.
 The repository is made to be a write only interface. This is why,
 while testing, we add a ``# type: ignore`` by reading from our implementation detail.
 
-Running the tests show that the eventstore is filled out by the bus.
+Running the tests show that the messagestore is filled out by the bus.
 
 ::
 
@@ -56,7 +56,7 @@ Running the tests show that the eventstore is filled out by the bus.
     it has been done here has an example. The messagebus is responsible of that
     part, nothing more.
 
-    By the way, what has to be is the real EventstoreRepository._add method that
+    By the way, what has to be is the real MessageStoreRepository._add method that
     received all kind of messages.
 
 All the basics of the messagebus has been introduced, so, for now, we will create

--- a/docs/source/user/cookbook/07_local_messagestore_01.py
+++ b/docs/source/user/cookbook/07_local_messagestore_01.py
@@ -1,10 +1,10 @@
 from collections.abc import MutableSequence
 from typing import Any, ClassVar
 
-from messagebus import AsyncEventstoreAbstractRepository, Message
+from messagebus import AsyncMessageStoreAbstractRepository, Message
 
 
-class InMemoryEventstoreRepository(AsyncEventstoreAbstractRepository):
+class InMemoryMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     messages: ClassVar[MutableSequence[Message[Any]]] = []
 
     async def _add(self, message: Message[Any]) -> None:

--- a/docs/source/user/cookbook/07_local_messagestore_02.py
+++ b/docs/source/user/cookbook/07_local_messagestore_02.py
@@ -6,7 +6,7 @@ import pytest
 from reading_club.domain.model import Book
 from reading_club.service.repositories import (
     AbstractBookRepository,
-    AsyncEventstoreAbstractRepository,
+    AsyncMessageStoreAbstractRepository,
     BookRepositoryError,
     BookRepositoryOperationResult,
     BookRepositoryResult,
@@ -21,7 +21,7 @@ from messagebus import (
 )
 
 
-class InMemoryEventstoreRepository(AsyncEventstoreAbstractRepository):
+class InMemoryMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     messages: ClassVar[MutableSequence[Message[Any]]] = []
 
     async def _add(self, message: Message[Any]) -> None:
@@ -51,7 +51,7 @@ class InMemoryBookRepository(AbstractBookRepository):
 class InMemoryUnitOfWork(AbstractUnitOfWork):
     def __init__(self, transport: AsyncAbstractEventstreamTransport):
         self.books = InMemoryBookRepository()
-        self.eventstore = InMemoryEventstoreRepository(
+        self.messagestore = InMemoryMessageStoreRepository(
             publisher=AsyncEventstreamPublisher(transport)
         )
 
@@ -66,4 +66,4 @@ def uow(transport: AsyncAbstractEventstreamTransport) -> Iterator[InMemoryUnitOf
     yield uow
     uow.books.books.clear()  # type: ignore
     uow.books.ix_books_isbn.clear()  # type: ignore
-    uow.eventstore.messages.clear()  # type: ignore
+    uow.messagestore.messages.clear()  # type: ignore

--- a/docs/source/user/cookbook/07_local_messagestore_03.py
+++ b/docs/source/user/cookbook/07_local_messagestore_03.py
@@ -26,7 +26,7 @@ async def test_bus_handler(
         assert book.unwrap().messages == []
         await transaction.commit()
 
-    assert uow.eventstore.messages == [  # type: ignore
+    assert uow.messagestore.messages == [  # type: ignore
         RegisterBook(
             id=uuidgen(1),
             isbn="0-321-12521-5",

--- a/docs/source/user/cookbook/08-sqlalchemy-uow.rst
+++ b/docs/source/user/cookbook/08-sqlalchemy-uow.rst
@@ -215,7 +215,7 @@ Before closing this chapter, lets run our tests and conclude
     tests/uow_sqla/test_repositories.py::test_book_add_err PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id_ok PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id_err PASSED
-    tests/uow_sqla/test_repositories.py::test_eventstore_add PASSED
+    tests/uow_sqla/test_repositories.py::test_messagestore_add PASSED
     tests/uow_sqla/test_transaction.py::test_commit PASSED
     tests/uow_sqla/test_transaction.py::test_rollback PASSED
     =========================== 9 passed in 0.43s ===========================

--- a/docs/source/user/cookbook/08_sqlalchemy_uow_04.py
+++ b/docs/source/user/cookbook/08_sqlalchemy_uow_04.py
@@ -11,14 +11,14 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from messagebus import (
     AsyncAbstractEventstreamTransport,
-    AsyncEventstoreAbstractRepository,
     AsyncEventstreamPublisher,
+    AsyncMessageStoreAbstractRepository,
     AsyncUnitOfWorkTransaction,
     Message,
 )
 
 
-class SQLEventstoreRepository(AsyncEventstoreAbstractRepository):
+class SQLMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     def __init__(self, session: AsyncSession, publisher: AsyncEventstreamPublisher):
         super().__init__(publisher)
         self.session = session
@@ -55,7 +55,7 @@ class SQLUnitOfWork(AbstractUnitOfWork):
     async def __aenter__(self) -> AsyncUnitOfWorkTransaction:
         self.messages = []
         self.session = self.session_factory()
-        self.eventstore = SQLEventstoreRepository(
+        self.messagestore = SQLMessageStoreRepository(
             self.session,
             AsyncEventstreamPublisher(self.transport),
         )

--- a/docs/source/user/cookbook/08_sqlalchemy_uow_10.py
+++ b/docs/source/user/cookbook/08_sqlalchemy_uow_10.py
@@ -6,12 +6,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def test_eventstore_add(
+async def test_messagestore_add(
     uow: SQLUnitOfWork, register_book_cmd: RegisterBook, sqla_session: AsyncSession
 ):
     register_book_cmd.id = uuidgen()
     async with uow as transaction:
-        await uow.eventstore.add(register_book_cmd)
+        await uow.messagestore.add(register_book_cmd)
         await transaction.commit()
 
     row = (

--- a/docs/source/user/cookbook/08_sqlalchemy_uow_11.py
+++ b/docs/source/user/cookbook/08_sqlalchemy_uow_11.py
@@ -2,15 +2,15 @@ from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from messagebus import (
-    AsyncEventstoreAbstractRepository,
     AsyncEventstreamPublisher,
+    AsyncMessageStoreAbstractRepository,
     Message,
 )
 
 from . import orm
 
 
-class SQLEventstoreRepository(AsyncEventstoreAbstractRepository):
+class SQLMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     def __init__(self, session: AsyncSession, publisher: AsyncEventstreamPublisher):
         super().__init__(publisher)
         self.session = session

--- a/docs/source/user/cookbook/09-testing-with-database-state.rst
+++ b/docs/source/user/cookbook/09-testing-with-database-state.rst
@@ -46,7 +46,7 @@ Now lets run our tests
     tests/uow_sqla/test_repositories.py::test_book_add_err[params0] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return a known book] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return an error] PASSED
-    tests/uow_sqla/test_repositories.py::test_eventstore_add PASSED
+    tests/uow_sqla/test_repositories.py::test_messagestore_add PASSED
     tests/uow_sqla/test_transaction.py::test_commit PASSED
     tests/uow_sqla/test_transaction.py::test_rollback PASSED
     =========================== 9 passed in 0.48s ===========================
@@ -89,7 +89,7 @@ Run our tests
     tests/uow_sqla/test_repositories.py::test_book_add_err[params0] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return a known book] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return an error] PASSED
-    tests/uow_sqla/test_repositories.py::test_eventstore_add PASSED
+    tests/uow_sqla/test_repositories.py::test_messagestore_add PASSED
     tests/uow_sqla/test_transaction.py::test_commit PASSED
     tests/uow_sqla/test_transaction.py::test_rollback PASSED
     ========================== 10 passed in 0.48s ===========================

--- a/docs/source/user/cookbook/10-sending-eventstream-using-celery.rst
+++ b/docs/source/user/cookbook/10-sending-eventstream-using-celery.rst
@@ -62,7 +62,7 @@ executor.
     tests/uow_sqla/test_repositories.py::test_book_add_err[params0] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return a known book] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return an error] PASSED
-    tests/uow_sqla/test_repositories.py::test_eventstore_add PASSED
+    tests/uow_sqla/test_repositories.py::test_messagestore_add PASSED
     tests/uow_sqla/test_transaction.py::test_commit PASSED
     tests/uow_sqla/test_transaction.py::test_rollback PASSED
     ========================== 11 passed in 4.37s ===========================
@@ -105,7 +105,7 @@ Lets run our test.
     tests/uow_sqla/test_repositories.py::test_book_add_err[params0] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return a known book] PASSED
     tests/uow_sqla/test_repositories.py::test_book_by_id[return an error] PASSED
-    tests/uow_sqla/test_repositories.py::test_eventstore_add PASSED
+    tests/uow_sqla/test_repositories.py::test_messagestore_add PASSED
     tests/uow_sqla/test_transaction.py::test_commit PASSED
     tests/uow_sqla/test_transaction.py::test_rollback PASSED
 

--- a/docs/source/user/cookbook/index.rst
+++ b/docs/source/user/cookbook/index.rst
@@ -16,7 +16,7 @@ using the messagebus library.
    04-service-handler
    05-message-bus
    06-eventstream
-   07-local-eventstore
+   07-local-messagestore
    08-sqlalchemy-uow
    09-testing-with-database-state
    10-sending-eventstream-using-celery

--- a/examples/reading-club/src/reading_club/adapters/uow_sqla/uow.py
+++ b/examples/reading-club/src/reading_club/adapters/uow_sqla/uow.py
@@ -6,13 +6,13 @@ from sqlalchemy import insert, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from messagebus import (  # AsyncEventstoreAbstractRepository,
+from messagebus import (  # AsyncMessageStoreAbstractRepository,
     AsyncAbstractEventstreamTransport,
     AsyncEventstreamPublisher,
     AsyncUnitOfWorkTransaction,
     Message,
 )
-from messagebus.service._async.repository import AsyncEventstoreAbstractRepository
+from messagebus.service._async.repository import AsyncMessageStoreAbstractRepository
 from reading_club.domain.model import Book
 from reading_club.service.repositories import (
     AbstractBookRepository,
@@ -25,7 +25,7 @@ from reading_club.service.uow import AbstractUnitOfWork
 from . import orm
 
 
-class SQLEventstoreRepository(AsyncEventstoreAbstractRepository):
+class SQLMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     def __init__(self, session: AsyncSession, publisher: AsyncEventstreamPublisher):
         super().__init__(publisher)
         self.session = session
@@ -87,7 +87,7 @@ class SQLUnitOfWork(AbstractUnitOfWork):
     async def __aenter__(self) -> AsyncUnitOfWorkTransaction:
         self.messages = []
         self.session = self.session_factory()
-        self.eventstore = SQLEventstoreRepository(
+        self.messagestore = SQLMessageStoreRepository(
             self.session,
             AsyncEventstreamPublisher(self.transport),
         )

--- a/examples/reading-club/tests/conftest.py
+++ b/examples/reading-club/tests/conftest.py
@@ -21,10 +21,10 @@ from messagebus import (
     AsyncMessageBus,
     Message,
 )
-from messagebus.service._async.repository import AsyncEventstoreAbstractRepository
+from messagebus.service._async.repository import AsyncMessageStoreAbstractRepository
 
 
-class InMemoryEventstoreRepository(AsyncEventstoreAbstractRepository):
+class InMemoryMessageStoreRepository(AsyncMessageStoreAbstractRepository):
     messages: ClassVar[MutableSequence[Message[Any]]] = []
 
     async def _add(self, message: Message[Any]) -> None:
@@ -69,7 +69,7 @@ class InMemoryBookRepository(AbstractBookRepository):
 class InMemoryUnitOfWork(AbstractUnitOfWork):
     def __init__(self, transport: AsyncAbstractEventstreamTransport):
         self.books = InMemoryBookRepository()
-        self.eventstore = InMemoryEventstoreRepository(
+        self.messagestore = InMemoryMessageStoreRepository(
             publisher=AsyncEventstreamPublisher(transport)
         )
 
@@ -99,7 +99,7 @@ def uow(transport: AsyncAbstractEventstreamTransport) -> Iterator[InMemoryUnitOf
     yield uow
     uow.books.books.clear()  # type: ignore
     uow.books.ix_books_isbn.clear()  # type: ignore
-    uow.eventstore.messages.clear()  # type: ignore
+    uow.messagestore.messages.clear()  # type: ignore
 
 
 # for performance reason, we reuse the bus here,

--- a/examples/reading-club/tests/test_service_handler_add_book.py
+++ b/examples/reading-club/tests/test_service_handler_add_book.py
@@ -103,7 +103,7 @@ async def test_bus_handler(
         assert book.unwrap().messages == []
         await transaction.commit()
 
-    assert uow.eventstore.messages == [  # type: ignore
+    assert uow.messagestore.messages == [  # type: ignore
         RegisterBook(
             id=uuidgen(1),
             isbn="0-321-12521-5",

--- a/examples/reading-club/tests/uow_sqla/test_repositories.py
+++ b/examples/reading-club/tests/uow_sqla/test_repositories.py
@@ -124,12 +124,12 @@ async def test_book_by_id(params: Mapping[str, Any], uow_with_data: SQLUnitOfWor
     assert res == params["expected_result"]
 
 
-async def test_eventstore_add(
+async def test_messagestore_add(
     uow: SQLUnitOfWork, register_book_cmd: RegisterBook, sqla_session: AsyncSession
 ):
     register_book_cmd.id = uuidgen()
     async with uow as transaction:
-        await uow.eventstore.add(register_book_cmd)
+        await uow.messagestore.add(register_book_cmd)
         await transaction.commit()
 
     row = (

--- a/scripts/gen_unasync.py
+++ b/scripts/gen_unasync.py
@@ -11,6 +11,7 @@ unasync.unasync_files(
             additional_replacements={
                 "_async": "_sync",
                 "TAsyncUow": "TSyncUow",
+                "TAsyncEventstore": "TSyncEventstore",
                 "async_listen": "sync_listen",
             },
         ),

--- a/scripts/gen_unasync.py
+++ b/scripts/gen_unasync.py
@@ -11,7 +11,7 @@ unasync.unasync_files(
             additional_replacements={
                 "_async": "_sync",
                 "TAsyncUow": "TSyncUow",
-                "TAsyncEventstore": "TSyncEventstore",
+                "TAsyncMessageStore": "TSyncMessageStore",
                 "async_listen": "sync_listen",
             },
         ),

--- a/src/messagebus/__init__.py
+++ b/src/messagebus/__init__.py
@@ -26,11 +26,11 @@ from .service._async.eventstream import (
 from .service._async.registry import AsyncMessageBus, async_listen
 from .service._async.repository import (
     AsyncAbstractRepository,
-    AsyncSinkholeEventstoreRepository,
+    AsyncSinkholeMessageStoreRepository,
 )
 from .service._async.unit_of_work import (
     AsyncAbstractUnitOfWork,
-    AsyncEventstoreAbstractRepository,
+    AsyncMessageStoreAbstractRepository,
     AsyncUnitOfWorkTransaction,
 )
 from .service._sync.dependency import SyncDependency
@@ -42,11 +42,11 @@ from .service._sync.eventstream import (
 from .service._sync.registry import SyncMessageBus, sync_listen
 from .service._sync.repository import (
     SyncAbstractRepository,
-    SyncSinkholeEventstoreRepository,
+    SyncSinkholeMessageStoreRepository,
 )
 from .service._sync.unit_of_work import (
     SyncAbstractUnitOfWork,
-    SyncEventstoreAbstractRepository,
+    SyncMessageStoreAbstractRepository,
     SyncUnitOfWorkTransaction,
 )
 from .service.eventstream import AbstractMessageSerializer
@@ -61,10 +61,10 @@ __all__ = [
     "AsyncAbstractRepository",
     # Unit of work
     "AsyncAbstractUnitOfWork",
-    "AsyncEventstoreAbstractRepository",
+    "AsyncMessageStoreAbstractRepository",
     "AsyncEventstreamPublisher",
     "AsyncMessageBus",
-    "AsyncSinkholeEventstoreRepository",
+    "AsyncSinkholeMessageStoreRepository",
     "AsyncSinkholeEventstreamTransport",
     "AsyncUnitOfWorkTransaction",
     "Command",
@@ -81,10 +81,10 @@ __all__ = [
     "SyncAbstractEventstreamTransport",
     "SyncAbstractRepository",
     "SyncAbstractUnitOfWork",
-    "SyncEventstoreAbstractRepository",
+    "SyncMessageStoreAbstractRepository",
     "SyncEventstreamPublisher",
     "SyncMessageBus",
-    "SyncSinkholeEventstoreRepository",
+    "SyncSinkholeMessageStoreRepository",
     "SyncSinkholeEventstreamTransport",
     "SyncUnitOfWorkTransaction",
     # Registry

--- a/src/messagebus/__init__.py
+++ b/src/messagebus/__init__.py
@@ -24,11 +24,13 @@ from .service._async.eventstream import (
     AsyncSinkholeEventstreamTransport,
 )
 from .service._async.registry import AsyncMessageBus, async_listen
-from .service._async.repository import AsyncAbstractRepository
+from .service._async.repository import (
+    AsyncAbstractRepository,
+    AsyncSinkholeEventstoreRepository,
+)
 from .service._async.unit_of_work import (
     AsyncAbstractUnitOfWork,
     AsyncEventstoreAbstractRepository,
-    AsyncSinkholeEventstoreRepository,
     AsyncUnitOfWorkTransaction,
 )
 from .service._sync.dependency import SyncDependency
@@ -38,11 +40,13 @@ from .service._sync.eventstream import (
     SyncSinkholeEventstreamTransport,
 )
 from .service._sync.registry import SyncMessageBus, sync_listen
-from .service._sync.repository import SyncAbstractRepository
+from .service._sync.repository import (
+    SyncAbstractRepository,
+    SyncSinkholeEventstoreRepository,
+)
 from .service._sync.unit_of_work import (
     SyncAbstractUnitOfWork,
     SyncEventstoreAbstractRepository,
-    SyncSinkholeEventstoreRepository,
     SyncUnitOfWorkTransaction,
 )
 from .service.eventstream import AbstractMessageSerializer

--- a/src/messagebus/service/_async/registry.py
+++ b/src/messagebus/service/_async/registry.py
@@ -22,7 +22,7 @@ from messagebus.service._async.dependency import (
 )
 from messagebus.service._async.unit_of_work import (
     AsyncUnitOfWorkTransaction,
-    TAsyncEventstore,
+    TAsyncMessageStore,
     TAsyncUow,
     TRepositories,
 )
@@ -131,7 +131,7 @@ class AsyncMessageBus(Generic[TRepositories]):
     async def handle(
         self,
         command: GenericCommand[Any],
-        uow: AsyncUnitOfWorkTransaction[TRepositories, TAsyncEventstore],
+        uow: AsyncUnitOfWorkTransaction[TRepositories, TAsyncMessageStore],
         **transient_dependencies: Any,
     ) -> Any:
         """
@@ -163,7 +163,7 @@ class AsyncMessageBus(Generic[TRepositories]):
                 for msghook in self.events_registry[msg_type]:  # type: ignore
                     await msghook(cast(GenericEvent[Any], message), uow, dependencies)
                     queue.extend(uow.uow.collect_new_events())
-            await uow.eventstore.add(message)
+            await uow.messagestore.add(message)
             idx += 1
         return ret
 

--- a/src/messagebus/service/_async/registry.py
+++ b/src/messagebus/service/_async/registry.py
@@ -22,6 +22,7 @@ from messagebus.service._async.dependency import (
 )
 from messagebus.service._async.unit_of_work import (
     AsyncUnitOfWorkTransaction,
+    TAsyncEventstore,
     TAsyncUow,
     TRepositories,
 )
@@ -130,7 +131,7 @@ class AsyncMessageBus(Generic[TRepositories]):
     async def handle(
         self,
         command: GenericCommand[Any],
-        uow: AsyncUnitOfWorkTransaction[TRepositories],
+        uow: AsyncUnitOfWorkTransaction[TRepositories, TAsyncEventstore],
         **transient_dependencies: Any,
     ) -> Any:
         """

--- a/src/messagebus/service/_async/repository.py
+++ b/src/messagebus/service/_async/repository.py
@@ -26,7 +26,7 @@ class AsyncAbstractRepository(abc.ABC, Generic[TModel_contra]):
     seen: MutableSequence[TModel_contra]
 
 
-class AsyncEventstoreAbstractRepository(abc.ABC):
+class AsyncMessageStoreAbstractRepository(abc.ABC):
     def __init__(self, publisher: AsyncEventstreamPublisher | None = None) -> None:
         self.publisher = publisher
         self.stream_buffer: MutableSequence[Message[Any]] = []
@@ -61,8 +61,8 @@ class AsyncEventstoreAbstractRepository(abc.ABC):
             await self.publisher.send_message(message)
 
 
-class AsyncSinkholeEventstoreRepository(AsyncEventstoreAbstractRepository):
-    """An eventstore that drop all the message."""
+class AsyncSinkholeMessageStoreRepository(AsyncMessageStoreAbstractRepository):
+    """A messagestore that drop all the message."""
 
     async def _add(self, message: Message[Any]) -> None:
         """Do nothing. The sinkhole drop every message."""

--- a/src/messagebus/service/_sync/registry.py
+++ b/src/messagebus/service/_sync/registry.py
@@ -23,7 +23,7 @@ from messagebus.service._sync.dependency import (
 from messagebus.service._sync.unit_of_work import (
     SyncUnitOfWorkTransaction,
     TRepositories,
-    TSyncEventstore,
+    TSyncMessageStore,
     TSyncUow,
 )
 
@@ -129,7 +129,7 @@ class SyncMessageBus(Generic[TRepositories]):
     def handle(
         self,
         command: GenericCommand[Any],
-        uow: SyncUnitOfWorkTransaction[TRepositories, TSyncEventstore],
+        uow: SyncUnitOfWorkTransaction[TRepositories, TSyncMessageStore],
         **transient_dependencies: Any,
     ) -> Any:
         """
@@ -161,7 +161,7 @@ class SyncMessageBus(Generic[TRepositories]):
                 for msghook in self.events_registry[msg_type]:  # type: ignore
                     msghook(cast(GenericEvent[Any], message), uow, dependencies)
                     queue.extend(uow.uow.collect_new_events())
-            uow.eventstore.add(message)
+            uow.messagestore.add(message)
             idx += 1
         return ret
 

--- a/src/messagebus/service/_sync/registry.py
+++ b/src/messagebus/service/_sync/registry.py
@@ -23,6 +23,7 @@ from messagebus.service._sync.dependency import (
 from messagebus.service._sync.unit_of_work import (
     SyncUnitOfWorkTransaction,
     TRepositories,
+    TSyncEventstore,
     TSyncUow,
 )
 
@@ -128,7 +129,7 @@ class SyncMessageBus(Generic[TRepositories]):
     def handle(
         self,
         command: GenericCommand[Any],
-        uow: SyncUnitOfWorkTransaction[TRepositories],
+        uow: SyncUnitOfWorkTransaction[TRepositories, TSyncEventstore],
         **transient_dependencies: Any,
     ) -> Any:
         """

--- a/src/messagebus/service/_sync/repository.py
+++ b/src/messagebus/service/_sync/repository.py
@@ -26,7 +26,7 @@ class SyncAbstractRepository(abc.ABC, Generic[TModel_contra]):
     seen: MutableSequence[TModel_contra]
 
 
-class SyncEventstoreAbstractRepository(abc.ABC):
+class SyncMessageStoreAbstractRepository(abc.ABC):
     def __init__(self, publisher: SyncEventstreamPublisher | None = None) -> None:
         self.publisher = publisher
         self.stream_buffer: MutableSequence[Message[Any]] = []
@@ -61,8 +61,8 @@ class SyncEventstoreAbstractRepository(abc.ABC):
             self.publisher.send_message(message)
 
 
-class SyncSinkholeEventstoreRepository(SyncEventstoreAbstractRepository):
-    """An eventstore that drop all the message."""
+class SyncSinkholeMessageStoreRepository(SyncMessageStoreAbstractRepository):
+    """A messagestore that drop all the message."""
 
     def _add(self, message: Message[Any]) -> None:
         """Do nothing. The sinkhole drop every message."""

--- a/src/messagebus/typing.py
+++ b/src/messagebus/typing.py
@@ -16,8 +16,8 @@ log = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 
-TAsyncUow = TypeVar("TAsyncUow", bound=AsyncAbstractUnitOfWork[Any])
-TSyncUow = TypeVar("TSyncUow", bound=SyncAbstractUnitOfWork[Any])
+TAsyncUow = TypeVar("TAsyncUow", bound=AsyncAbstractUnitOfWork[Any, Any])
+TSyncUow = TypeVar("TSyncUow", bound=SyncAbstractUnitOfWork[Any, Any])
 TMessage = TypeVar("TMessage", bound=Message[Any])
 
 AsyncMessageHandler = Callable[

--- a/tests/_async/handlers/dummy.py
+++ b/tests/_async/handlers/dummy.py
@@ -11,20 +11,20 @@ from tests._async.conftest import (
 
 
 @async_listen
-async def handler(command: DummyCommand, uow: AsyncAbstractUnitOfWork[Any]): ...
+async def handler(command: DummyCommand, uow: AsyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @async_listen
-async def handler_evt1(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any]): ...
+async def handler_evt1(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @async_listen
-async def handler_evt2(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any]): ...
+async def handler_evt2(command: DummyEvent, uow: AsyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @async_listen
 async def handler_with_dependency_injection(
     command: AnotherDummyCommand,
-    uow: AsyncAbstractUnitOfWork[Any],
+    uow: AsyncAbstractUnitOfWork[Any, Any],
     notifier: Notifier,
 ): ...

--- a/tests/_async/test_dependency.py
+++ b/tests/_async/test_dependency.py
@@ -9,6 +9,7 @@ from messagebus.service._async.unit_of_work import (
     AsyncUnitOfWorkTransaction,
 )
 from tests._async.conftest import (
+    AsyncDummyEventStore,
     AsyncDummyUnitOfWorkWithEvents,
     AsyncEventstreamTransport,
     DummyCommand,
@@ -21,7 +22,7 @@ from tests._async.conftest import (
 
 async def listen_command(
     cmd: DummyCommand,
-    uow: AsyncUnitOfWorkTransaction[Repositories],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
     notifier: Notifier,
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
@@ -62,7 +63,7 @@ class TransientDependency(AsyncDependency):
 
 async def listen_with_transient(
     command: DummyCommand,
-    uow: AsyncAbstractUnitOfWork[Any],
+    uow: AsyncAbstractUnitOfWork[Any, Any],
     tracker: TransientDependency,
 ):
     tracker.tracks.append("tracked")
@@ -101,7 +102,7 @@ async def test_transient_dependency_missing(
 
 async def listen_with_optional(
     command: DummyCommand,
-    uow: AsyncAbstractUnitOfWork[Any],
+    uow: AsyncAbstractUnitOfWork[Any, Any],
     tracker: TransientDependency | None = None,
 ):
     if tracker:

--- a/tests/_async/test_dependency.py
+++ b/tests/_async/test_dependency.py
@@ -9,7 +9,7 @@ from messagebus.service._async.unit_of_work import (
     AsyncUnitOfWorkTransaction,
 )
 from tests._async.conftest import (
-    AsyncDummyEventStore,
+    AsyncDummyMessageStore,
     AsyncDummyUnitOfWorkWithEvents,
     AsyncEventstreamTransport,
     DummyCommand,
@@ -22,7 +22,7 @@ from tests._async.conftest import (
 
 async def listen_command(
     cmd: DummyCommand,
-    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
     notifier: Notifier,
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
@@ -36,12 +36,12 @@ async def listen_command(
 async def test_store_events_and_publish(
     bus: AsyncMessageBus[Repositories],
     eventstream_transport: AsyncEventstreamTransport,
-    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: AsyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_command)
-    async with uow_with_eventstore as tuow:
+    async with uow_with_messagestore as tuow:
         await bus.handle(dummy_command, tuow)
         await tuow.commit()
     assert notifier.inbox == [
@@ -72,13 +72,13 @@ async def listen_with_transient(
 async def test_transient_dependency(
     bus: AsyncMessageBus[Repositories],
     eventstream_transport: AsyncEventstreamTransport,
-    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: AsyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     tmp = TransientDependency()
     bus.add_listener(DummyCommand, listen_with_transient)
-    async with uow_with_eventstore as tuow:
+    async with uow_with_messagestore as tuow:
         await bus.handle(dummy_command, tuow, tracker=tmp)
         await tuow.commit()
     assert tmp.tracks == ["tracked"]
@@ -88,13 +88,13 @@ async def test_transient_dependency(
 async def test_transient_dependency_missing(
     bus: AsyncMessageBus[Repositories],
     eventstream_transport: AsyncEventstreamTransport,
-    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: AsyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_with_transient)
     with pytest.raises(MissingDependencyError) as ctx:
-        async with uow_with_eventstore as tuow:
+        async with uow_with_messagestore as tuow:
             await bus.handle(dummy_command, tuow)
             await tuow.commit()
     assert str(ctx.value) == "Missing messagebus dependency 'tracker'"
@@ -112,13 +112,13 @@ async def listen_with_optional(
 async def test_optional_dependency(
     bus: AsyncMessageBus[Repositories],
     eventstream_transport: AsyncEventstreamTransport,
-    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: AsyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     tmp = TransientDependency()
     bus.add_listener(DummyCommand, listen_with_optional)
-    async with uow_with_eventstore as tuow:
+    async with uow_with_messagestore as tuow:
         await bus.handle(dummy_command, tuow, tracker=tmp)
         await tuow.commit()
     assert tmp.tracks == ["optionnaly_tracked"]
@@ -128,12 +128,12 @@ async def test_optional_dependency(
 async def test_optional_dependency_missing(
     bus: AsyncMessageBus[Repositories],
     eventstream_transport: AsyncEventstreamTransport,
-    uow_with_eventstore: AsyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: AsyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_with_optional)
-    async with uow_with_eventstore as tuow:
+    async with uow_with_messagestore as tuow:
         await bus.handle(dummy_command, tuow)
         await tuow.commit()
     # we tests that there is no issue here

--- a/tests/_async/test_eventstore.py
+++ b/tests/_async/test_eventstore.py
@@ -1,6 +1,7 @@
 from messagebus.service._async.registry import AsyncMessageBus
 from messagebus.service._async.unit_of_work import AsyncUnitOfWorkTransaction
 from tests._async.conftest import (
+    AsyncDummyEventStore,
     AsyncDummyUnitOfWorkWithEvents,
     AsyncEventstreamTransport,
     DummyCommand,
@@ -12,7 +13,8 @@ from tests._async.conftest import (
 
 
 async def listen_command(
-    cmd: DummyCommand, uow: AsyncUnitOfWorkTransaction[Repositories]
+    cmd: DummyCommand,
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
     foo = DummyModel(id=cmd.id, counter=0)

--- a/tests/_async/test_registry.py
+++ b/tests/_async/test_registry.py
@@ -4,6 +4,7 @@ import pytest
 
 from messagebus.service._async.registry import AsyncMessageBus, ConfigurationError
 from tests._async.conftest import (
+    AsyncDummyEventStore,
     AsyncUnitOfWorkTransaction,
     DummyCommand,
     DummyEvent,
@@ -17,7 +18,8 @@ conftest_mod = __name__.replace("test_registry", "conftest")
 
 
 async def listen_command(
-    cmd: DummyCommand, uow: AsyncUnitOfWorkTransaction[Repositories]
+    cmd: DummyCommand,
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
     foo = DummyModel(id=cmd.id, counter=0)
@@ -27,7 +29,7 @@ async def listen_command(
 
 
 async def listen_event(
-    cmd: DummyEvent, uow: AsyncUnitOfWorkTransaction[Repositories]
+    cmd: DummyEvent, uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore]
 ) -> None:
     """This event is indented to be fire by the message bus."""
     rfoo = await uow.foos.get(cmd.id)
@@ -37,7 +39,7 @@ async def listen_event(
 
 async def test_messagebus(
     bus: AsyncMessageBus[Repositories],
-    tuow: AsyncUnitOfWorkTransaction[Repositories],
+    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
 ):
     """
     Test that the message bus is firing command and event.
@@ -78,7 +80,7 @@ async def test_messagebus(
 
 async def test_messagebus_handle_only_message(
     bus: AsyncMessageBus[Repositories],
-    tuow: AsyncUnitOfWorkTransaction[Repositories],
+    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
 ):
     class Msg:
         def __repr__(self):
@@ -172,7 +174,7 @@ def test_scan_relative(bus: AsyncMessageBus[Any]):
 
 async def listen_command_with_dependency(
     cmd: DummyCommand,
-    uow: AsyncUnitOfWorkTransaction[Repositories],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
     dummy_dep: Notifier,
     dummy_dep2: Notifier | None = None,
 ) -> DummyModel:
@@ -183,7 +185,7 @@ async def listen_command_with_dependency(
 
 
 async def test_messagebus_dependency(
-    uow: AsyncUnitOfWorkTransaction[Repositories],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
 ):
     d: dict[str, str] = {}
     bus = AsyncMessageBus[Repositories](dummy_dep=d)

--- a/tests/_async/test_registry.py
+++ b/tests/_async/test_registry.py
@@ -4,7 +4,7 @@ import pytest
 
 from messagebus.service._async.registry import AsyncMessageBus, ConfigurationError
 from tests._async.conftest import (
-    AsyncDummyEventStore,
+    AsyncDummyMessageStore,
     AsyncUnitOfWorkTransaction,
     DummyCommand,
     DummyEvent,
@@ -19,7 +19,7 @@ conftest_mod = __name__.replace("test_registry", "conftest")
 
 async def listen_command(
     cmd: DummyCommand,
-    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
     foo = DummyModel(id=cmd.id, counter=0)
@@ -29,7 +29,8 @@ async def listen_command(
 
 
 async def listen_event(
-    cmd: DummyEvent, uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore]
+    cmd: DummyEvent,
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
 ) -> None:
     """This event is indented to be fire by the message bus."""
     rfoo = await uow.foos.get(cmd.id)
@@ -39,7 +40,7 @@ async def listen_event(
 
 async def test_messagebus(
     bus: AsyncMessageBus[Repositories],
-    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
 ):
     """
     Test that the message bus is firing command and event.
@@ -80,7 +81,7 @@ async def test_messagebus(
 
 async def test_messagebus_handle_only_message(
     bus: AsyncMessageBus[Repositories],
-    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    tuow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
 ):
     class Msg:
         def __repr__(self):
@@ -174,7 +175,7 @@ def test_scan_relative(bus: AsyncMessageBus[Any]):
 
 async def listen_command_with_dependency(
     cmd: DummyCommand,
-    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
     dummy_dep: Notifier,
     dummy_dep2: Notifier | None = None,
 ) -> DummyModel:
@@ -185,7 +186,7 @@ async def listen_command_with_dependency(
 
 
 async def test_messagebus_dependency(
-    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyEventStore],
+    uow: AsyncUnitOfWorkTransaction[Repositories, AsyncDummyMessageStore],
 ):
     d: dict[str, str] = {}
     bus = AsyncMessageBus[Repositories](dummy_dep=d)

--- a/tests/_async/test_unit_of_work.py
+++ b/tests/_async/test_unit_of_work.py
@@ -115,6 +115,7 @@ async def test_detach_transaction(uow: AsyncDummyUnitOfWork):
         await uow.foos.add(DummyModel(id="2", counter=1))
         await uow.foos.add(DummyModel(id="3", counter=1))
         await tuow.commit()
+
     async with uow as tuow:
         iter_foos = uow.foos.find(id="2")
         await tuow.detach()

--- a/tests/_sync/handlers/dummy.py
+++ b/tests/_sync/handlers/dummy.py
@@ -11,20 +11,20 @@ from tests._sync.conftest import (
 
 
 @sync_listen
-def handler(command: DummyCommand, uow: SyncAbstractUnitOfWork[Any]): ...
+def handler(command: DummyCommand, uow: SyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @sync_listen
-def handler_evt1(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any]): ...
+def handler_evt1(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @sync_listen
-def handler_evt2(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any]): ...
+def handler_evt2(command: DummyEvent, uow: SyncAbstractUnitOfWork[Any, Any]): ...
 
 
 @sync_listen
 def handler_with_dependency_injection(
     command: AnotherDummyCommand,
-    uow: SyncAbstractUnitOfWork[Any],
+    uow: SyncAbstractUnitOfWork[Any, Any],
     notifier: Notifier,
 ): ...

--- a/tests/_sync/test_dependency.py
+++ b/tests/_sync/test_dependency.py
@@ -14,7 +14,7 @@ from tests._sync.conftest import (
     DummyModel,
     Notifier,
     Repositories,
-    SyncDummyEventStore,
+    SyncDummyMessageStore,
     SyncDummyUnitOfWorkWithEvents,
     SyncEventstreamTransport,
 )
@@ -22,7 +22,7 @@ from tests._sync.conftest import (
 
 def listen_command(
     cmd: DummyCommand,
-    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
     notifier: Notifier,
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
@@ -36,12 +36,12 @@ def listen_command(
 def test_store_events_and_publish(
     bus: SyncMessageBus[Repositories],
     eventstream_transport: SyncEventstreamTransport,
-    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: SyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_command)
-    with uow_with_eventstore as tuow:
+    with uow_with_messagestore as tuow:
         bus.handle(dummy_command, tuow)
         tuow.commit()
     assert notifier.inbox == [
@@ -72,13 +72,13 @@ def listen_with_transient(
 def test_transient_dependency(
     bus: SyncMessageBus[Repositories],
     eventstream_transport: SyncEventstreamTransport,
-    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: SyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     tmp = TransientDependency()
     bus.add_listener(DummyCommand, listen_with_transient)
-    with uow_with_eventstore as tuow:
+    with uow_with_messagestore as tuow:
         bus.handle(dummy_command, tuow, tracker=tmp)
         tuow.commit()
     assert tmp.tracks == ["tracked"]
@@ -88,13 +88,13 @@ def test_transient_dependency(
 def test_transient_dependency_missing(
     bus: SyncMessageBus[Repositories],
     eventstream_transport: SyncEventstreamTransport,
-    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: SyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_with_transient)
     with pytest.raises(MissingDependencyError) as ctx:
-        with uow_with_eventstore as tuow:
+        with uow_with_messagestore as tuow:
             bus.handle(dummy_command, tuow)
             tuow.commit()
     assert str(ctx.value) == "Missing messagebus dependency 'tracker'"
@@ -112,13 +112,13 @@ def listen_with_optional(
 def test_optional_dependency(
     bus: SyncMessageBus[Repositories],
     eventstream_transport: SyncEventstreamTransport,
-    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: SyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     tmp = TransientDependency()
     bus.add_listener(DummyCommand, listen_with_optional)
-    with uow_with_eventstore as tuow:
+    with uow_with_messagestore as tuow:
         bus.handle(dummy_command, tuow, tracker=tmp)
         tuow.commit()
     assert tmp.tracks == ["optionnaly_tracked"]
@@ -128,12 +128,12 @@ def test_optional_dependency(
 def test_optional_dependency_missing(
     bus: SyncMessageBus[Repositories],
     eventstream_transport: SyncEventstreamTransport,
-    uow_with_eventstore: SyncDummyUnitOfWorkWithEvents,
+    uow_with_messagestore: SyncDummyUnitOfWorkWithEvents,
     dummy_command: DummyCommand,
     notifier: Notifier,
 ):
     bus.add_listener(DummyCommand, listen_with_optional)
-    with uow_with_eventstore as tuow:
+    with uow_with_messagestore as tuow:
         bus.handle(dummy_command, tuow)
         tuow.commit()
     # we tests that there is no issue here

--- a/tests/_sync/test_dependency.py
+++ b/tests/_sync/test_dependency.py
@@ -14,6 +14,7 @@ from tests._sync.conftest import (
     DummyModel,
     Notifier,
     Repositories,
+    SyncDummyEventStore,
     SyncDummyUnitOfWorkWithEvents,
     SyncEventstreamTransport,
 )
@@ -21,7 +22,7 @@ from tests._sync.conftest import (
 
 def listen_command(
     cmd: DummyCommand,
-    uow: SyncUnitOfWorkTransaction[Repositories],
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
     notifier: Notifier,
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
@@ -62,7 +63,7 @@ class TransientDependency(SyncDependency):
 
 def listen_with_transient(
     command: DummyCommand,
-    uow: SyncAbstractUnitOfWork[Any],
+    uow: SyncAbstractUnitOfWork[Any, Any],
     tracker: TransientDependency,
 ):
     tracker.tracks.append("tracked")
@@ -101,7 +102,7 @@ def test_transient_dependency_missing(
 
 def listen_with_optional(
     command: DummyCommand,
-    uow: SyncAbstractUnitOfWork[Any],
+    uow: SyncAbstractUnitOfWork[Any, Any],
     tracker: TransientDependency | None = None,
 ):
     if tracker:

--- a/tests/_sync/test_eventstore.py
+++ b/tests/_sync/test_eventstore.py
@@ -6,13 +6,15 @@ from tests._sync.conftest import (
     DummyModel,
     MyMetadata,
     Repositories,
+    SyncDummyEventStore,
     SyncDummyUnitOfWorkWithEvents,
     SyncEventstreamTransport,
 )
 
 
 def listen_command(
-    cmd: DummyCommand, uow: SyncUnitOfWorkTransaction[Repositories]
+    cmd: DummyCommand,
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
     foo = DummyModel(id=cmd.id, counter=0)

--- a/tests/_sync/test_registry.py
+++ b/tests/_sync/test_registry.py
@@ -9,7 +9,7 @@ from tests._sync.conftest import (
     DummyModel,
     Notifier,
     Repositories,
-    SyncDummyEventStore,
+    SyncDummyMessageStore,
     SyncUnitOfWorkTransaction,
 )
 from tests._sync.handlers import dummy
@@ -19,7 +19,7 @@ conftest_mod = __name__.replace("test_registry", "conftest")
 
 def listen_command(
     cmd: DummyCommand,
-    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
 ) -> DummyModel:
     """This command raise an event played by the message bus."""
     foo = DummyModel(id=cmd.id, counter=0)
@@ -29,7 +29,8 @@ def listen_command(
 
 
 def listen_event(
-    cmd: DummyEvent, uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore]
+    cmd: DummyEvent,
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
 ) -> None:
     """This event is indented to be fire by the message bus."""
     rfoo = uow.foos.get(cmd.id)
@@ -39,7 +40,7 @@ def listen_event(
 
 def test_messagebus(
     bus: SyncMessageBus[Repositories],
-    tuow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    tuow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
 ):
     """
     Test that the message bus is firing command and event.
@@ -80,7 +81,7 @@ def test_messagebus(
 
 def test_messagebus_handle_only_message(
     bus: SyncMessageBus[Repositories],
-    tuow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    tuow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
 ):
     class Msg:
         def __repr__(self):
@@ -174,7 +175,7 @@ def test_scan_relative(bus: SyncMessageBus[Any]):
 
 def listen_command_with_dependency(
     cmd: DummyCommand,
-    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
     dummy_dep: Notifier,
     dummy_dep2: Notifier | None = None,
 ) -> DummyModel:
@@ -185,7 +186,7 @@ def listen_command_with_dependency(
 
 
 def test_messagebus_dependency(
-    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyEventStore],
+    uow: SyncUnitOfWorkTransaction[Repositories, SyncDummyMessageStore],
 ):
     d: dict[str, str] = {}
     bus = SyncMessageBus[Repositories](dummy_dep=d)

--- a/tests/_sync/test_unit_of_work.py
+++ b/tests/_sync/test_unit_of_work.py
@@ -113,6 +113,7 @@ def test_detach_transaction(uow: SyncDummyUnitOfWork):
         uow.foos.add(DummyModel(id="2", counter=1))
         uow.foos.add(DummyModel(id="3", counter=1))
         tuow.commit()
+
     with uow as tuow:
         iter_foos = uow.foos.find(id="2")
         tuow.detach()


### PR DESCRIPTION
eventstore has been renamed to messagestore, because locally, we store all kind of message.

Not thate the eventstream stays intact because users are not supposed to send commands
in its eventstream.

A generic has been added to extends the message store to more method than just "add"