### PR TITLE
Expose model transaction status

### DIFF
--- a/src/messagebus/__init__.py
+++ b/src/messagebus/__init__.py
@@ -16,6 +16,7 @@ from .domain.model import (
     Metadata,
     Model,
     TMetadata,
+    TransactionStatus,
 )
 from .service._async.dependency import AsyncDependency
 from .service._async.eventstream import (
@@ -91,6 +92,7 @@ __all__ = [
     "SyncSinkholeMessageStoreRepository",
     "SyncSinkholeEventstreamTransport",
     "SyncUnitOfWorkTransaction",
+    "TransactionStatus",
     # Registry
     "async_listen",
     "sync_listen",

--- a/src/messagebus/domain/model/__init__.py
+++ b/src/messagebus/domain/model/__init__.py
@@ -9,6 +9,7 @@ from .message import (
 )
 from .metadata import Metadata, TMetadata
 from .model import GenericModel, Model
+from .transaction import TransactionStatus
 
 __all__ = [
     "Command",
@@ -20,4 +21,5 @@ __all__ = [
     "Metadata",
     "Model",
     "TMetadata",
+    "TransactionStatus",
 ]

--- a/src/messagebus/domain/model/transaction.py
+++ b/src/messagebus/domain/model/transaction.py
@@ -1,0 +1,28 @@
+"""Transaction models."""
+
+import enum
+
+
+class TransactionError(RuntimeError):
+    """A runtime error raised if the transaction lifetime is inappropriate."""
+
+
+class TransactionStatus(enum.Enum):
+    """Transaction status used to ensure transaction lifetime."""
+
+    running = "running"
+    """Initial state of the transaction status in the context manager."""
+    rolledback = "rolledback"
+    """state of the transaction status after it has been aborted."""
+    committed = "committed"
+    """state of the transaction status after it has been committed."""
+    closed = "closed"
+    """state of the transaction status after the with state block."""
+    streaming = "streaming"
+    """
+    Unsafe way to manually exit the transaction manager for streaming purpose.
+
+    While streaming response in some context like FastAPI or Starlette
+    StreamingResponse, the transaction must be closed lately, usually in a
+    finally block to close the transaction.
+    """

--- a/src/messagebus/service/_async/unit_of_work.py
+++ b/src/messagebus/service/_async/unit_of_work.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import abc
-import enum
 from collections.abc import Iterator
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
@@ -12,6 +11,7 @@ from messagebus.domain.model import Message
 
 if TYPE_CHECKING:
     from messagebus.service._async.dependency import AsyncDependency  # coverage: ignore
+from messagebus.domain.model.transaction import TransactionError, TransactionStatus
 from messagebus.service._async.repository import (
     AsyncAbstractMessageStoreRepository,
     AsyncAbstractRepository,
@@ -21,31 +21,6 @@ from messagebus.service._async.repository import (
 TAsyncMessageStore = TypeVar(
     "TAsyncMessageStore", bound=AsyncAbstractMessageStoreRepository
 )
-
-
-class TransactionError(RuntimeError):
-    """A runtime error raised if the transaction lifetime is inappropriate."""
-
-
-class TransactionStatus(enum.Enum):
-    """Transaction status used to ensure transaction lifetime."""
-
-    running = "running"
-    """Initial state of the transaction status in the context manager."""
-    rolledback = "rolledback"
-    """state of the transaction status after it has been aborted."""
-    committed = "committed"
-    """state of the transaction status after it has been committed."""
-    closed = "closed"
-    """state of the transaction status after the with state block."""
-    streaming = "streaming"
-    """
-    Unsafe way to manually exit the transaction manager for streaming purpose.
-
-    While streaming response in some context like FastAPI or Starlette
-    StreamingResponse, the transaction must be closed lately, usually in a
-    finally block to close the transaction.
-    """
 
 
 TRepositories = TypeVar("TRepositories", bound=AsyncAbstractRepository[Any])

--- a/src/messagebus/service/_sync/unit_of_work.py
+++ b/src/messagebus/service/_sync/unit_of_work.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import abc
-import enum
 from collections.abc import Iterator
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
@@ -12,6 +11,7 @@ from messagebus.domain.model import Message
 
 if TYPE_CHECKING:
     from messagebus.service._sync.dependency import SyncDependency  # coverage: ignore
+from messagebus.domain.model.transaction import TransactionError, TransactionStatus
 from messagebus.service._sync.repository import (
     SyncAbstractMessageStoreRepository,
     SyncAbstractRepository,
@@ -21,31 +21,6 @@ from messagebus.service._sync.repository import (
 TSyncMessageStore = TypeVar(
     "TSyncMessageStore", bound=SyncAbstractMessageStoreRepository
 )
-
-
-class TransactionError(RuntimeError):
-    """A runtime error raised if the transaction lifetime is inappropriate."""
-
-
-class TransactionStatus(enum.Enum):
-    """Transaction status used to ensure transaction lifetime."""
-
-    running = "running"
-    """Initial state of the transaction status in the context manager."""
-    rolledback = "rolledback"
-    """state of the transaction status after it has been aborted."""
-    committed = "committed"
-    """state of the transaction status after it has been committed."""
-    closed = "closed"
-    """state of the transaction status after the with state block."""
-    streaming = "streaming"
-    """
-    Unsafe way to manually exit the transaction manager for streaming purpose.
-
-    While streaming response in some context like FastAPI or Starlette
-    StreamingResponse, the transaction must be closed lately, usually in a
-    finally block to close the transaction.
-    """
 
 
 TRepositories = TypeVar("TRepositories", bound=SyncAbstractRepository[Any])


### PR DESCRIPTION
Don't duplicate the transactionstatus between sync and async version.

Expose it in the main api.